### PR TITLE
custom random value generation for flows

### DIFF
--- a/woke/testing/fuzzing/fuzz_test.py
+++ b/woke/testing/fuzzing/fuzz_test.py
@@ -112,8 +112,11 @@ class FuzzTest:
                         f"Could not find a valid flow to run.\nFlows that have reached their max_times: {max_times_flows}\nFlows that do not satisfy their precondition: {precondition_flows}"
                     )
                 flow = random.choices(valid_flows, weights=weights)[0]
+
                 flow_params = [
-                    generate(v)
+                    getattr(type(self), k)()
+                    if callable(getattr(type(self), k, None))
+                    else generate(v)
                     for k, v in get_type_hints(flow, include_extras=True).items()
                     if k != "return"
                 ]


### PR DESCRIPTION
This change allows the user to define a custom method to generate values for a flow parameter.  In the example below, a custom generation function is defined for a Balance dataclass.   

The change checks if there is a callable static member on the class with the same name as a parameter to a flow, if there is it calls that member.  If not ,  the existing `generate(v)` is executed for the type. 

```

from woke.testing.fuzzing import generators
from woke.development.core import Address
from woke.testing.core import default_chain
from woke.development.primitive_types import uint
from dataclasses import dataclass
from woke.testing.fuzzing import flow
from woke.testing.fuzzing.fuzz_test import FuzzTest

@dataclass
class Balance:
    account: Address
    balance: uint


def random_balance(min: uint , max: uint):

    def f():
        return Balance(
            account=generators.random_address(),
            balance=generators.random_int(min=min, max=max),
        )

    return f


class ExampleTest(FuzzTest):


    st_balance = random_balance(min=500, max=4000)

    @flow()
    def flow1(self, st_balance: Balance) -> None:
        print("balance", st_balance)


@default_chain.connect()
def test_default():
    default_chain.set_default_accounts(default_chain.accounts[0])
    ExampleTest().run(sequences_count=1, flows_count=5)

```

Output:
```
balance Balance(account=0xe7330130daeddc42358248d643d7a0ec62cb6ff1, balance=3406)
balance Balance(account=0x468ba713d7b51a3ce82966353a92b9deca95a4fd, balance=2850)
balance Balance(account=0x305d215c5af3952f5f4a00f791e89cabbbfd251d, balance=3545)
balance Balance(account=0xf218e55639bdaa8841dbc71d4e6c66d0ada1ee74, balance=3788)
balance Balance(account=0xaa21884724429e1f1123d08488ab237014243239, balance=2364)
```
