### PR TITLE
Feat: Add --config Cli option

### DIFF
--- a/woke/cli/__main__.py
+++ b/woke/cli/__main__.py
@@ -33,9 +33,16 @@ if platform.system() != "Windows":
 @click.option(
     "--profile", is_flag=True, default=False, help="Enable profiling using cProfile."
 )
+@click.option(
+    "--config",
+    "custom_config_path",  # name of parameter of `main` function
+    type=click.Path(exists=True),
+    default="woke.toml",
+    help="Path to config file to use.",
+)
 @click.version_option(message="%(version)s", package_name="woke")
 @click.pass_context
-def main(ctx: Context, debug: bool, profile: bool) -> None:
+def main(ctx: Context, debug: bool, custom_config_path: str, profile: bool) -> None:
     if profile:
         import atexit
         import cProfile
@@ -58,6 +65,7 @@ def main(ctx: Context, debug: bool, profile: bool) -> None:
 
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
+    ctx.obj["custom_config_path"] = custom_config_path
 
     if platform.system() == "Windows":
         asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
@@ -84,7 +92,7 @@ def config(ctx: Context) -> None:
     """Print loaded config options in JSON format."""
     from woke.config import WokeConfig
 
-    config = WokeConfig()
+    config = WokeConfig(ctx["custom_config_path"])
     config.load_configs()
     console.print_json(str(config))
 
@@ -98,7 +106,7 @@ def woke_solc() -> None:
     from woke.svm import SolcVersionManager
 
     logging.basicConfig(level=logging.CRITICAL)
-    config = WokeConfig()
+    config = WokeConfig(None)
     config.load_configs()
     svm = SolcVersionManager(config)
 

--- a/woke/cli/__main__.py
+++ b/woke/cli/__main__.py
@@ -92,7 +92,7 @@ def config(ctx: Context) -> None:
     """Print loaded config options in JSON format."""
     from woke.config import WokeConfig
 
-    config = WokeConfig(ctx["custom_config_path"])
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()
     console.print_json(str(config))
 

--- a/woke/cli/accounts.py
+++ b/woke/cli/accounts.py
@@ -34,7 +34,7 @@ def run_accounts(ctx: Context):
 
     from woke.config import WokeConfig
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()
     ctx.obj["config"] = config
 

--- a/woke/cli/compile.py
+++ b/woke/cli/compile.py
@@ -173,7 +173,7 @@ def run_compile(
     """Compile the project."""
     from woke.config import WokeConfig
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()  # load ~/.woke/config.toml and ./woke.toml
 
     asyncio.run(

--- a/woke/cli/detect.py
+++ b/woke/cli/detect.py
@@ -36,7 +36,7 @@ def run_detect(
     from ..utils.file_utils import is_relative_to
     from .console import console
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()  # load ~/.woke/config.toml and ./woke.toml
 
     sol_files: Set[Path] = set()

--- a/woke/cli/fuzz.py
+++ b/woke/cli/fuzz.py
@@ -59,7 +59,7 @@ def run_fuzz(
     if process_count < coverage:
         raise ValueError("Coverage must be less than or equal to process count.")
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()  # load ~/.woke/config.toml and ./woke.toml
 
     random_seeds = [bytes.fromhex(seed) for seed in seeds]

--- a/woke/cli/init.py
+++ b/woke/cli/init.py
@@ -87,7 +87,7 @@ def run_init(ctx: Context, force: bool):
     """Initialize project."""
     from woke.config import WokeConfig
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()
     ctx.obj["config"] = config
 

--- a/woke/cli/lsp.py
+++ b/woke/cli/lsp.py
@@ -47,7 +47,7 @@ def run_lsp(context: click.Context, port: int):
     """
     from woke.config import WokeConfig
 
-    config = WokeConfig()
+    config = WokeConfig(context.obj["custom_config_path"])
     config.load_configs()  # load ~/.woke/config.toml and ./woke.toml
 
     asyncio.run(run_server(config, port))

--- a/woke/cli/run.py
+++ b/woke/cli/run.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Tuple
 
 import rich_click as click
+from click.core import Context
 
 
 def _get_module_name(path: Path, root: Path) -> str:
@@ -26,7 +27,10 @@ def _get_module_name(path: Path, root: Path) -> str:
     default=False,
     help="Do not print transaction info.",
 )
-def run_run(paths: Tuple[str, ...], debug: bool, ask: bool, silent: bool) -> None:
+@click.pass_context
+def run_run(
+    ctx: Context, paths: Tuple[str, ...], debug: bool, ask: bool, silent: bool
+) -> None:
     """Run a Woke script."""
 
     import importlib.util
@@ -44,7 +48,7 @@ def run_run(paths: Tuple[str, ...], debug: bool, ask: bool, silent: bool) -> Non
 
     from .console import console
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()
     get_config().update(
         {

--- a/woke/cli/svm.py
+++ b/woke/cli/svm.py
@@ -21,7 +21,7 @@ def run_svm(ctx: Context):
     """Run Woke Solc Version Manager."""
     from woke.config import WokeConfig
 
-    config = WokeConfig()
+    config = WokeConfig(ctx.obj["custom_config_path"])
     config.load_configs()
     ctx.obj["config"] = config
 

--- a/woke/cli/test.py
+++ b/woke/cli/test.py
@@ -55,7 +55,7 @@ def run_test(
     from woke.development.globals import chain_interfaces_manager, set_config
     from woke.testing.pytest_plugin import PytestWokePlugin
 
-    config = WokeConfig()
+    config = WokeConfig(context.obj["custom_config_path"])
     config.load_configs()  # load ~/.woke/config.toml and ./woke.toml
 
     set_config(config)

--- a/woke/config/woke_config.py
+++ b/woke/config/woke_config.py
@@ -32,15 +32,17 @@ class UnsupportedPlatformError(Exception):
 
 
 class WokeConfig:
-    __project_root_path: Path
     __global_config_path: Path
     __global_data_path: Path
+    __project_root_path: Path
+    __custom_config_path: Path
     __loaded_files: Set[Path]
     __config_raw: Dict[str, Any]
     __config: TopLevelConfig
 
     def __init__(
         self,
+        custom_config_path: Optional[Union[str, Path]],
         *_,
         project_root_path: Optional[Union[str, Path]] = None,
     ):
@@ -118,6 +120,11 @@ class WokeConfig:
         with change_cwd(self.__project_root_path):
             self.__config = TopLevelConfig()
         self.__config_raw = self.__config.dict(by_alias=True)
+
+        if custom_config_path is not None:
+            self.__custom_config_path = Path(custom_config_path).resolve(strict=True)
+        else:
+            self.__custom_config_path = self.__project_root_path / "woke.toml"
 
     def __str__(self) -> str:
         return self.__config.json(by_alias=True, exclude_unset=True)
@@ -274,7 +281,7 @@ class WokeConfig:
         self.__config_raw = self.__config.dict(by_alias=True)
 
         self.load(self.global_config_path / "config.toml")
-        self.load(self.project_root_path / "woke.toml")
+        self.load(self.custom_config_path)
 
     def load(self, path: Path) -> None:
         """
@@ -320,6 +327,13 @@ class WokeConfig:
         Return the system path of the currently open project.
         """
         return self.__project_root_path
+
+    @property
+    def custom_config_path(self) -> Path:
+        """
+        Return the system path to the custom config file.
+        """
+        return self.__custom_config_path
 
     @property
     def min_solidity_version(self) -> SolidityVersion:


### PR DESCRIPTION
This Pr sketches out a way to add a --config cli option to woke to specify a config file other than cwd / woke.toml. This can be useful for monorepos, for placing all woke tests and config in a `/woke` directory in a project and many other use cases

Certainty about changes being correct = 5/10.

First commit message for visibility:

```
cli/__main__:
* In the top level cli function (`main`), add a parameter `custom_config_path`, set by `--config`. Add this `str` value to click Context (`ctx.obj`) so it is available in subcommands.

config/woke_config:
* Add `__custom_custom_path` variable to WokeConfig (and re-arrange instance variables to make it more logical).
* In `WokeConfig.load_configs()`, load from `self.custom_config_path instead of `self.project_root_path / "woke.toml"`. At the same time, require a passing of `custom_config_path` to `WokeConfig()`. ((This strict Api will ensure that we don't miss places in the current code.)) If it is None; it defaults to `self.__project_root_path / "woke.toml"`. The end result should be that passing `None` will replicate current behavior and passing another str | Path will allow a custom config.

cli/
* Whenever WokeConfig is created in cli/, do `WokeConfig(ctx.obj["custom_config_path"])`.

TODOs:
* Ensure the rest of the project's invariants hold.
* Ensure test suite remains intact.
* Test this feature.
* Update documentation.
```