### PR TITLE
Adding the user config to add prefix of link to the contract for mainly wsl users 

### DIFF
--- a/wake/config/data_model.py
+++ b/wake/config/data_model.py
@@ -404,7 +404,10 @@ class GeneralConfig(WakeConfigModel):
     """
     Format of links used in detectors and printers.
     """
-
+    pytypes_link_prefix: str = ""
+    """
+    Prefix to add to links in contract pytypes.
+    """
 
 class PrintersConfig(WakeConfigModel):
     """

--- a/wake/config/data_model.py
+++ b/wake/config/data_model.py
@@ -409,6 +409,7 @@ class GeneralConfig(WakeConfigModel):
     Prefix to add to links in contract pytypes.
     """
 
+
 class PrintersConfig(WakeConfigModel):
     """
     Holds general printer config options for all printers.

--- a/wake/development/pytypes_generator.py
+++ b/wake/development/pytypes_generator.py
@@ -87,11 +87,11 @@ def _binary_search(lines: List[Tuple[bytes, int]], x: int) -> int:
     return l - 1
 
 
-def _path_to_uri(path: Path) -> str:
+def _path_to_uri(path: Path, config: WakeConfig) -> str:
     if os.name == "nt":
-        return "file:" + pathname2url(str(path.resolve()))
+        return "file:" + config.general.pytypes_link_prefix + pathname2url(str(path.resolve()))
     else:
-        return "file://" + pathname2url(str(path.resolve()))
+        return "file://" + config.general.pytypes_link_prefix + pathname2url(str(path.resolve()))
 
 
 def _parse_opcodes(opcodes: str) -> List[Tuple[int, str, int, Optional[int]]]:
@@ -339,7 +339,7 @@ class TypeGenerator:
                     fn.source_unit.file, fn.byte_location[0]
                 )
                 source_code_link = (
-                    f"[Source code]({_path_to_uri(fn.source_unit.file)}#{line + 1})"
+                    f"[Source code]({_path_to_uri(fn.source_unit.file, self.__config)}#{line + 1})"
                 )
                 break
 
@@ -519,7 +519,7 @@ class TypeGenerator:
         )
         self.add_str_to_types(1, '"""', 1)
         self.add_str_to_types(
-            1, f"[Source code]({_path_to_uri(contract.source_unit.file)}#{line + 1})", 1
+            1, f"[Source code]({_path_to_uri(contract.source_unit.file, self.__config)}#{line + 1})", 1
         )
         self.add_str_to_types(1, '"""', 1)
 
@@ -769,7 +769,7 @@ class TypeGenerator:
             )
             self.add_str_to_types(
                 indent + 1,
-                f"[Source code]({_path_to_uri(struct.source_unit.file)}#{line + 1})",
+                f"[Source code]({_path_to_uri(struct.source_unit.file, self.__config)}#{line + 1})",
                 2,
             )
             self.add_str_to_types(indent + 1, "Attributes:", 1)
@@ -803,7 +803,7 @@ class TypeGenerator:
             self.add_str_to_types(indent + 1, '"""', 1)
             self.add_str_to_types(
                 indent + 1,
-                f"[Source code]({_path_to_uri(enum.source_unit.file)}#{line + 1})",
+                f"[Source code]({_path_to_uri(enum.source_unit.file, self.__config)}#{line + 1})",
                 2,
             )
             self.add_str_to_types(indent + 1, '"""', 1)
@@ -872,7 +872,7 @@ class TypeGenerator:
             self.add_str_to_types(indent + 1, '"""', 1)
             self.add_str_to_types(
                 indent + 1,
-                f"[Source code]({_path_to_uri(error.source_unit.file)}#{line + 1})",
+                f"[Source code]({_path_to_uri(error.source_unit.file, self.__config)}#{line + 1})",
                 1 if len(parameters) == 0 else 2,
             )
 
@@ -962,7 +962,7 @@ class TypeGenerator:
             self.add_str_to_types(indent + 1, '"""', 1)
             self.add_str_to_types(
                 indent + 1,
-                f"[Source code]({_path_to_uri(event.source_unit.file)}#{line + 1})",
+                f"[Source code]({_path_to_uri(event.source_unit.file, self.__config)}#{line + 1})",
                 1 if len(parameters) == 0 else 2,
             )
 
@@ -1344,7 +1344,7 @@ class TypeGenerator:
         self.add_str_to_types(2, '"""', 1)
         self.add_str_to_types(
             2,
-            f"[Source code]({_path_to_uri(declaration.source_unit.file)}#{line + 1})",
+            f"[Source code]({_path_to_uri(declaration.source_unit.file, self.__config)}#{line + 1})",
             1 if len(param_names) + len(returns) == 0 else 2,
         )
         if len(param_names) > 0:
@@ -1398,7 +1398,7 @@ class TypeGenerator:
         self.add_str_to_types(2, '"""', 1)
         self.add_str_to_types(
             2,
-            f"[Source code]({_path_to_uri(declaration.source_unit.file)}#{line + 1})",
+            f"[Source code]({_path_to_uri(declaration.source_unit.file, self.__config)}#{line + 1})",
             1 if len(param_names) + len(returns) == 0 else 2,
         )
         if len(param_names) > 0:


### PR DESCRIPTION
The currently generated pytypes source code link is generated like this.

```
[Source code](file:///home/meditationduck/projects/audit-meditationduck/contracts/MeditationDuck.sol#18)
```

However, for the WSL, it can not reach the actual source code.

This pull request is for adding a new config to add a prefix to solve the path for the WSL.

The new config will be like this in the `wake.toml` 
```
~~
[general]
pytypes_link_prefix = "wsl.localhost/Ubuntu"
~~
```

which generates links in the pytypes like below which solves the path issue.

```
[Source code](file://wsl.localhost/Ubuntu/home/meditationduck/projects/audit-meditationduck/contracts/MeditationDuck.sol#18)
```


I was aware there is the config for the printer or detector.
Probably it is possible to merge them, but the format of those paths is different.

Additionally, it seems possible to replace the path of the `source_unit.path` at `compile.py`. However, it will be more complicated changes.