### PR TITLE
🐛 Fix tx type detection with DRPC

### DIFF
--- a/wake/development/core.py
+++ b/wake/development/core.py
@@ -1656,6 +1656,7 @@ class Chain(ABC):
                             {
                                 "type": 2,
                                 "maxPriorityFeePerGas": 0,
+                                "to": "0x0000000000000000000000000000000000000000",
                             }
                         )
                         self._default_tx_type = 2
@@ -1665,6 +1666,7 @@ class Chain(ABC):
                                 {
                                     "type": 1,
                                     "accessList": [],
+                                    "to": "0x0000000000000000000000000000000000000000",
                                 }
                             )
                             self._default_tx_type = 1


### PR DESCRIPTION
DRPC node requires `to` to be set for calls