### PR TITLE
Multiprocess Testing Deadlock

### DIFF
--- a/wake/development/chain_interfaces.py
+++ b/wake/development/chain_interfaces.py
@@ -191,7 +191,7 @@ class ChainInterfaceAbc(ABC):
                 args += ["-k", hardfork]
 
         console.print(f"Launching {' '.join(args)}")
-        process = subprocess.Popen(args, stdout=subprocess.DEVNULL)
+        process = subprocess.Popen(args, stdout=subprocess.DEVNULL, start_new_session=True)
 
         try:
             start = time.perf_counter()

--- a/wake/development/globals.py
+++ b/wake/development/globals.py
@@ -247,6 +247,9 @@ class ChainInterfaceManager:
                             snapshot_reverted = True
                     except JsonRpcError:
                         pass
+                    except Exception: 
+                        logger.warning("Exception happen", exc_info=True)
+                        pass
                     break
 
         if snapshot_reverted and params is not None:

--- a/wake/development/globals.py
+++ b/wake/development/globals.py
@@ -236,22 +236,21 @@ class ChainInterfaceManager:
     def free(self, chain_interface: ChainInterfaceAbc) -> None:
         snapshot_reverted = False
         params = None
-
+        index = None
         for chain_params, chain_interfaces in self._chain_interfaces.items():
             for i, (c, snapshot) in enumerate(chain_interfaces):
                 if c == chain_interface:
                     params = chain_params
-                    self._chain_interfaces[chain_params].pop(i)
+                    index = i
                     try:
                         if snapshot is not None and chain_interface.revert(snapshot):
                             snapshot_reverted = True
                     except JsonRpcError:
                         pass
                     except Exception: 
-                        logger.warning("Exception happen", exc_info=True)
                         pass
                     break
-
+        self._chain_interfaces[chain_params].pop(index)
         if snapshot_reverted and params is not None:
             logger.debug(
                 "Freeing chain with uri=%s, accounts=%s, chain_id=%s, fork=%s, hardfork=%s",

--- a/wake/testing/core.py
+++ b/wake/testing/core.py
@@ -80,7 +80,8 @@ class Chain(wake.development.core.Chain):
             self.gas_price = self._chain_interface.get_gas_price()
 
     def _connect_finalize(self) -> None:
-        connected_chains.remove(self)
+        if self._chain_interface in connected_chains:
+            connected_chains.remove(self)
         chain_interfaces_manager.free(self._chain_interface)
 
     def _new_private_key(self, extra_entropy: bytes = b"") -> bytes:

--- a/wake/testing/pytest_plugin_multiprocess_server.py
+++ b/wake/testing/pytest_plugin_multiprocess_server.py
@@ -106,7 +106,10 @@ class PytestWakePluginMultiprocessServer:
         self._queue.cancel_join_thread()
         for p, conn in self._processes.values():
             p.terminate()
-            p.join()
+            p.join(timeout=5)
+            if p.is_alive():
+                p.kill()
+                p.join()
             conn.close()
 
         self._queue.close()


### PR DESCRIPTION
## Description
The error happened when terminating the process after receiving SIGINT. and it opens the debugger in the child process.
which still opened the process after SIGTERM was sent and those child processes can not join. which makes a kind of deadlock.



## Related Tickets & Documents

This situation could happen also in single-process testing. but in this case user can just control+c again and then terminate.

I first try to make consistent testing results in single-process testing, and usually, the cause of testing failure is something about connection. and it is better to be KeyboardInterrupt.
Thus, I make the anvil process a new session. 

Then some different errors happen when freeing the chain. also, some anvils do not end and become orphans.

I add the exception. this handling should be ok since they are doing it if it is success-free and those chain is usable. otherwise, close the chain and if needed it will create again. 


- Related Issue #
- Closes #

- [x] I clicked on "Allow edits from maintainers"