### PR TITLE
Printing random seed when exception debugger opening

### DIFF
--- a/wake/cli/test.py
+++ b/wake/cli/test.py
@@ -28,6 +28,7 @@ def run_no_pytest(
     import importlib.util
     import inspect
     import shutil
+    from functools import partial
 
     from wake.development.globals import (
         attach_debugger,
@@ -88,7 +89,7 @@ def run_no_pytest(
         console.print(f"Using random seed {random_seeds[0].hex()}")
 
         if debug:
-            set_exception_handler(attach_debugger)
+            set_exception_handler(partial(attach_debugger, seed=random_seeds[0]))
 
         if coverage:
             set_coverage_handler(CoverageHandler(config))
@@ -99,7 +100,7 @@ def run_no_pytest(
                     func()
                 except Exception:
                     if debug:
-                        attach_debugger(*sys.exc_info())
+                        attach_debugger(*sys.exc_info(), seed=random_seeds[0])
                     raise
                 reset_exception_handled()
         finally:

--- a/wake/development/globals.py
+++ b/wake/development/globals.py
@@ -60,6 +60,7 @@ def attach_debugger(
     e_type: Optional[Type[BaseException]],
     e: Optional[BaseException],
     tb: Optional[TracebackType],
+    seed: Optional[bytes] = None,
 ):
     global _exception_handled
 
@@ -93,9 +94,13 @@ def attach_debugger(
             break
         frames_up += 1
 
-    p = _init_pdb(
-        commands=["up %d" % frames_up] if frames_up > 0 else [],
-    )
+    commands = []
+    if frames_up > 0:
+        commands.append("up %d" % frames_up)
+    if seed is not None:
+        commands.append(f"random_seed = bytes.fromhex('{seed.hex()}')")
+
+    p = _init_pdb(commands=commands)
     p.reset()
     p.interaction(None, tb)
 

--- a/wake/development/globals.py
+++ b/wake/development/globals.py
@@ -98,7 +98,7 @@ def attach_debugger(
     if frames_up > 0:
         commands.append("up %d" % frames_up)
     if seed is not None:
-        commands.append(f"random_seed = bytes.fromhex('{seed.hex()}')")
+        commands.append(f"wake_random_seed = bytes.fromhex('{seed.hex()}')")
 
     p = _init_pdb(commands=commands)
     p.reset()

--- a/wake/testing/fuzzing/fuzzer.py
+++ b/wake/testing/fuzzing/fuzzer.py
@@ -73,7 +73,7 @@ def _run(
             attach: bool = err_child_conn.recv()
             if attach:
                 sys.stdin = os.fdopen(0)
-                attach_debugger(e_type, e, tb)
+                attach_debugger(e_type, e, tb, seed=random_seed)
         finally:
             finished_event.set()
 

--- a/wake/testing/pytest_plugin_multiprocess.py
+++ b/wake/testing/pytest_plugin_multiprocess.py
@@ -103,6 +103,7 @@ class PytestWakePluginMultiprocess:
         try:
             if attach:
                 sys.stdin = os.fdopen(0)
+                console.print(f"Used random seed '{self._random_seed.hex()}'")
                 attach_debugger(e_type, e, tb)
         finally:
             self._setup_stdio()

--- a/wake/testing/pytest_plugin_multiprocess.py
+++ b/wake/testing/pytest_plugin_multiprocess.py
@@ -103,8 +103,7 @@ class PytestWakePluginMultiprocess:
         try:
             if attach:
                 sys.stdin = os.fdopen(0)
-                console.print(f"Used random seed '{self._random_seed.hex()}'")
-                attach_debugger(e_type, e, tb)
+                attach_debugger(e_type, e, tb, seed=self._random_seed)
         finally:
             self._setup_stdio()
             self._conn.send(("exception_handled",))

--- a/wake/testing/pytest_plugin_single.py
+++ b/wake/testing/pytest_plugin_single.py
@@ -1,6 +1,8 @@
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Type
 
 from pytest import Session
+
+from types import TracebackType
 
 from wake.cli.console import console
 from wake.config import WakeConfig
@@ -25,6 +27,7 @@ class PytestWakePluginSingle:
     _cov_proc_count: Optional[int]
     _random_seeds: List[bytes]
     _debug: bool
+    _exception_handled: bool
 
     def __init__(
         self,
@@ -40,10 +43,22 @@ class PytestWakePluginSingle:
 
     def pytest_runtest_setup(self, item):
         reset_exception_handled()
+        self._exception_handled = False
 
     def pytest_exception_interact(self, node, call, report):
-        if self._debug:
-            attach_debugger(call.excinfo.type, call.excinfo.value, call.excinfo.tb)
+        if self._debug and not self._exception_handled:
+            self._exception_handler(call.excinfo.type, call.excinfo.value, call.excinfo.tb)
+            
+
+    def _exception_handler(
+        self,
+        e_type: Optional[Type[BaseException]],
+        e: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        self._exception_handled = True
+        console.print(f"Used random seed '{self._random_seeds[0].hex()}'")
+        attach_debugger(e_type, e, tb)
 
     def pytest_runtestloop(self, session: Session):
         if (
@@ -64,7 +79,7 @@ class PytestWakePluginSingle:
         console.print(f"Using random seed '{self._random_seeds[0].hex()}'")
 
         if self._debug:
-            set_exception_handler(attach_debugger)
+            set_exception_handler(self._exception_handler)
         if coverage:
             set_coverage_handler(CoverageHandler(self._config))
 

--- a/wake/testing/pytest_plugin_single.py
+++ b/wake/testing/pytest_plugin_single.py
@@ -67,6 +67,7 @@ class PytestWakePluginSingle:
         coverage = self._cov_proc_count == 1 or self._cov_proc_count == -1
 
         random.seed(self._random_seeds[0])
+        console.print(f"Using random seed '{self._random_seeds[0].hex()}'")
 
         if self._debug:
             set_exception_handler(partial(attach_debugger, seed=self._random_seeds[0]))


### PR DESCRIPTION
## Description

Printing the random seed when exceptions happen while testing.

We can see random seeds without closing the debugger.

We can investigate exceptions using the debugger at the same time reproduce exceptions in other wake.
