### PR TITLE
Exception handler missing condition to open handler

### DIFF
--- a/wake/testing/pytest_plugin_multiprocess.py
+++ b/wake/testing/pytest_plugin_multiprocess.py
@@ -93,6 +93,9 @@ class PytestWakePluginMultiprocess:
         if self._keyboard_interrupt:
             return
 
+        if self._exception_handled:
+            return
+
         self._cleanup_stdio()
         self._exception_handled = True
 


### PR DESCRIPTION
When an exception happens in the test in multiple try-except blocks, e.g., Assertion error in the `snapshot_and_revert()` block. Wake asks to open the exception handler multiple times.

## Description
Since the child process sends a message to the parent process to ask to start the debugger. but we want to open the debugger only the first time when the exception handler called, but the if-statement was located later in sending a message.

I added the condition to check the handled before or not so exceptional handling debugger only opens once.

