### PR TITLE
 Unrelated Errors When Interrupting Single-Process Testing with SIGINT

### DIFF
--- a/wake/development/chain_interfaces.py
+++ b/wake/development/chain_interfaces.py
@@ -194,7 +194,7 @@ class ChainInterfaceAbc(ABC):
 
         console.print(f"Launching {' '.join(args)}")
         try:
-            process = subprocess.Popen(args, stdout=subprocess.DEVNULL)
+            process = subprocess.Popen(args, stdout=subprocess.DEVNULL, start_new_session=True)
         except FileNotFoundError:
             if args[0] == "anvil" and platform.system() != "Windows":
                 args[0] = str(Path.home() / ".foundry/bin/anvil")


### PR DESCRIPTION

## Description

During testing—particularly fuzz testing with a single process—pressing `Ctrl+C` to send a `SIGINT` signal results in an error unrelated to the interruption. Instead of handling the `SIGINT`, the program displays a different error, often associated with a WebSocket.

<img width="936" alt="Screenshot 2024-11-29 at 2 33 54" src="https://github.com/user-attachments/assets/c35d14f8-39fa-415a-85f3-b39ea7628c60">

The root cause of this issue is that when the system is testing, it sends transactions to Anvil (used here as an example) and waits to receive data back. If the user sends a `SIGINT` (by pressing `Ctrl+C`) while the program is waiting for data (`recv()`), the receive operation is canceled. The program then proceeds to finalize the chain interfaces, which involves further communication with Anvil. However, due to the canceled receive operation, the finalization process may receive unexpected data or residual responses from the previous operation. This results in an unexpected error during finalization, which is reported to the user instead of the expected interruption due to `SIGINT`.

## Fix

To address this issue, the code has been modified to prevent interruptions during data reception from the chain. By temporarily suppressing `SIGINT` signals during the `recv()` operation, we ensure that data reception is not interrupted. Once the data has been fully received, any pending `SIGINT` is then processed. This allows the program to handle the interruption appropriately after ensuring the data integrity during communication with Anvil.

This change does not cause much overhead in the testing.

* with fix
89.28
92.31
97.42

* without fix
88.22
96.62
89.11

<!--

## Related Tickets & Documents


For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.


- Related Issue #
- Closes #
-->
- [ ] I clicked on "Allow edits from maintainers"