### PR TITLE
Feat/sake chain manager

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ Wake can be configured using configuration options loaded from multiple sources 
     [general]
     call_trace_options = [
         "contract_name", "function_name", "named_arguments", "status",
-        "call_type", "value", "return_value", "error"
+        "call_type", "value", "return_value", "error", "events"
     ]
     json_rpc_timeout = 15
     link_format = "vscode://file/{path}:{line}:{col}"
@@ -214,7 +214,7 @@ Every detector supports at least the `min_confidence` and `min_impact` options:
 
 | Option                            | Description                                                                                                                                                                                                          |
 |:----------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <nobr>`call_trace_options`</nobr> | What information to display in call traces. Possible options: `contract_name`, `address`, `function_name`, `named_arguments`, `arguments`, `status`, `call_type`, `value`, `gas`, `sender`, `return_value`, `error`. |
+| <nobr>`call_trace_options`</nobr> | What information to display in call traces. Possible options: `contract_name`, `address`, `function_name`, `named_arguments`, `arguments`, `status`, `call_type`, `value`, `gas`, `sender`, `return_value`, `error`, `events`. |
 | `json_rpc_timeout`                | Timeout in seconds when communicating with a node via JSON-RPC.                                                                                                                                                      |
 | `link_format`                     | Format of links to source code files used in detectors and printers. The link should contain `{path}`, `{line}` and `{col}` placeholders.                                                                            |
 

--- a/wake/config/data_model.py
+++ b/wake/config/data_model.py
@@ -145,7 +145,9 @@ class SolcConfig(WakeConfigModel):
     """
     Solidity files in these paths are excluded from compilation unless imported from a non-excluded file.
     """
-    include_paths: FrozenSet[PurePath] = Field(default_factory=lambda: frozenset([Path.cwd() / "node_modules"]))
+    include_paths: FrozenSet[PurePath] = Field(
+        default_factory=lambda: frozenset([Path.cwd() / "node_modules"])
+    )
     """
     Paths where to search for Solidity files imported using direct (non-relative) import paths.
     """
@@ -176,7 +178,9 @@ class SolcConfig(WakeConfigModel):
     Metadata config options.
     """
 
-    _normalize_paths = field_validator("allow_paths", "include_paths", "exclude_paths", mode="before")(normalize_paths)
+    _normalize_paths = field_validator(
+        "allow_paths", "include_paths", "exclude_paths", mode="before"
+    )(normalize_paths)
 
     @field_serializer("target_version", when_used="json")
     def serialize_target_version(self, version: Optional[SolidityVersion], info):
@@ -279,7 +283,9 @@ class DetectorsConfig(WakeConfigModel):
     Useful for ignoring detections in dependencies.
     """
 
-    _normalize_paths = field_validator("ignore_paths", "exclude_paths", mode="before")(normalize_paths)
+    _normalize_paths = field_validator("ignore_paths", "exclude_paths", mode="before")(
+        normalize_paths
+    )
 
 
 # namespace for detector configs
@@ -434,6 +440,7 @@ class GeneralConfig(WakeConfigModel):
             "value",
             "return_value",
             "error",
+            "events",
         ]
     )
     """

--- a/wake/deployment/core.py
+++ b/wake/deployment/core.py
@@ -25,7 +25,7 @@ from wake.development.core import (
     check_connected,
     fix_library_abi,
 )
-from wake.development.globals import chain_interfaces_manager, get_config
+from wake.development.globals import chain_interfaces_manager, get_config, get_verbosity
 from wake.development.json_rpc.communicator import JsonRpcError
 from wake.development.transactions import (
     Eip1559Transaction,
@@ -404,7 +404,15 @@ class Chain(wake.development.core.Chain):
         config = get_config()
         if config.deployment.silent:
             return
-        pprint(tx, console=console, max_string=200)
+
+        tx_copy = tx.copy()
+        if "data" in tx_copy:
+            tx_copy["data"] = "0x" + tx_copy["data"].hex()
+
+        if get_verbosity() > 0:
+            pprint(tx_copy, console=console, max_string=None)
+        else:
+            pprint(tx_copy, console=console, max_string=1024)
 
         if config.deployment.confirm_transactions:
             confirm = Confirm.ask("Sign and send transaction?")

--- a/wake/development/call_trace.py
+++ b/wake/development/call_trace.py
@@ -557,6 +557,24 @@ class CallTrace:
 
         return ret
 
+    @property
+    def error_string(self) -> Optional[str]:
+        if self._error_name is None:
+            return None
+
+        ret = f"{self._error_name}("
+        for i, (arg, arg_name) in enumerate(
+            zip(self.error_arguments or [], self._error_names or [])
+        ):
+            if arg_name is not None and len(arg_name.strip()) > 0:
+                ret += f"{arg_name.strip()}={repr(arg)}"
+            else:
+                ret += repr(arg)
+            if i < len(self.error_arguments or []) - 1:
+                ret += ", "
+
+        return ret
+
     def dict(self, config: WakeConfig) -> Dict[str, Union[Optional[str], List]]:
         options = config.general.call_trace_options
         ret: Dict[str, Union[Optional[str], List]] = {}

--- a/wake/development/call_trace.py
+++ b/wake/development/call_trace.py
@@ -42,7 +42,7 @@ from .core import (
 )
 from .globals import get_config, get_verbosity
 from .internal import read_from_memory
-from .utils import get_contract_info_from_explorer
+from .utils import get_name_abi_from_explorer
 
 if TYPE_CHECKING:
     from wake.config import WakeConfig
@@ -147,6 +147,25 @@ def get_precompiled_info(
         )
     else:
         raise ValueError(f"Unknown precompiled contract address: {addr}")
+
+
+def _get_info_from_explorer(addr: Address, chain_id: int) -> Optional[Tuple[str, Dict]]:
+    try:
+        name, abi = get_name_abi_from_explorer(addr, chain_id)
+    except Exception:
+        return None
+
+    abi_dict = {}
+    # TODO library ABI is different and has to be fixed to compute the correct selector
+    # however, it is not possible to detect if a contract is a library or not without parsing the source code
+    for abi_item in abi:
+        if abi_item["type"] in {"constructor", "fallback", "receive"}:
+            abi_dict[abi_item["type"]] = abi_item
+        elif abi_item["type"] == "function":
+            abi_dict[eth_utils.abi.function_abi_to_4byte_selector(abi_item)] = abi_item
+        elif abi_item["type"] == "error":
+            abi_dict[eth_utils.abi.function_abi_to_4byte_selector(abi_item)] = abi_item
+    return name, abi_dict
 
 
 def _decode_precompiled(
@@ -840,7 +859,7 @@ class CallTrace:
                     to.address, b"" if "data" not in tx_params else tx_params["data"]
                 )
             elif chain._fork is not None:
-                explorer_info = get_contract_info_from_explorer(
+                explorer_info = _get_info_from_explorer(
                     to.address,
                     chain._forked_chain_id
                     if chain._forked_chain_id is not None
@@ -1136,7 +1155,7 @@ class CallTrace:
                     if Address(0) < addr <= Address(9):
                         precompiled_info = get_precompiled_info(addr, data)
                     elif chain._fork is not None:
-                        explorer_info = get_contract_info_from_explorer(
+                        explorer_info = _get_info_from_explorer(
                             addr,
                             chain._forked_chain_id
                             if chain._forked_chain_id is not None

--- a/wake/development/call_trace.py
+++ b/wake/development/call_trace.py
@@ -685,6 +685,7 @@ class CallTrace:
                 ret += repr(arg)
             if i < len(self.error_arguments or []) - 1:
                 ret += ", "
+        ret += ")"
 
         return ret
 

--- a/wake/development/call_trace.py
+++ b/wake/development/call_trace.py
@@ -262,6 +262,7 @@ def _decode_event_args(
     topic_index = 0
     decoded_indexed = []
     types = []
+    non_indexed_abi = []
 
     for arg in fix_library_abi(abi):
         if arg["indexed"]:
@@ -280,10 +281,11 @@ def _decode_event_args(
             topic_index += 1
         else:
             types.append(eth_utils.abi.collapse_if_tuple(arg))
+            non_indexed_abi.append(arg)
 
     decoded = list(
         _normalize(arg, type, chain)
-        for arg, type in zip(eth_abi.abi.decode(types, data), abi)
+        for arg, type in zip(eth_abi.abi.decode(types, data), non_indexed_abi)
     )
     merged = []
 

--- a/wake/development/chain_interfaces.py
+++ b/wake/development/chain_interfaces.py
@@ -686,6 +686,12 @@ class AnvilChainInterface(ChainInterfaceAbc):
             else [hex(num_blocks)],
         )
 
+    def dump_state(self) -> str:
+        return self._communicator.send_request("anvil_dumpState")
+
+    def load_state(self, state: str) -> None:
+        self._communicator.send_request("anvil_loadState", [state])
+
 
 class GanacheChainInterface(ChainInterfaceAbc):
     @property

--- a/wake/development/chain_interfaces.py
+++ b/wake/development/chain_interfaces.py
@@ -261,6 +261,15 @@ class ChainInterfaceAbc(ABC):
             communicator.__exit__(None, None, None)
             raise
 
+    @property
+    def connection_uri(self) -> str:
+        return self._communicator.uri
+
+    @property
+    @abstractmethod
+    def type(self) -> str:
+        ...
+
     def close(self) -> None:
         self._communicator.__exit__(None, None, None)
         if self._process is not None:
@@ -533,6 +542,10 @@ class ChainInterfaceAbc(ABC):
 
 
 class HardhatChainInterface(ChainInterfaceAbc):
+    @property
+    def type(self) -> str:
+        return "hardhat"
+
     def get_accounts(self) -> List[str]:
         return self._communicator.send_request("eth_accounts")
 
@@ -604,6 +617,10 @@ class HardhatChainInterface(ChainInterfaceAbc):
 
 
 class AnvilChainInterface(ChainInterfaceAbc):
+    @property
+    def type(self) -> str:
+        return "anvil"
+
     def get_accounts(self) -> List[str]:
         return self._communicator.send_request("eth_accounts")
 
@@ -671,6 +688,10 @@ class AnvilChainInterface(ChainInterfaceAbc):
 
 
 class GanacheChainInterface(ChainInterfaceAbc):
+    @property
+    def type(self) -> str:
+        return "ganache"
+
     def get_accounts(self) -> List[str]:
         return self._communicator.send_request("eth_accounts")
 
@@ -742,6 +763,10 @@ class GanacheChainInterface(ChainInterfaceAbc):
 
 
 class GethLikeChainInterfaceAbc(ChainInterfaceAbc, ABC):
+    @property
+    def type(self) -> str:
+        return self._name.lower()
+
     @property
     @abstractmethod
     def _name(self) -> str:

--- a/wake/development/core.py
+++ b/wake/development/core.py
@@ -2474,11 +2474,9 @@ class Chain(ABC):
 
             for input in fix_library_abi(abi["inputs"]):
                 if input["indexed"]:
-                    if (
-                        input["type"] in {"string", "bytes"}
-                        or input["internalType"].startswith("struct ")
-                        or input["type"].endswith("]")
-                    ):
+                    if input["type"] in {"string", "bytes", "tuple"} or input[
+                        "type"
+                    ].endswith("]"):
                         topic_type = "bytes32"
                     else:
                         topic_type = input["type"]

--- a/wake/development/json_rpc/communicator.py
+++ b/wake/development/json_rpc/communicator.py
@@ -43,6 +43,7 @@ class JsonRpcCommunicator:
     _protocol: ProtocolAbc
     _request_id: int
     _connected: bool
+    uri: str
 
     def __init__(self, config: WakeConfig, uri: str):
         if uri.startswith(("http://", "https://")):
@@ -56,6 +57,7 @@ class JsonRpcCommunicator:
 
         self._request_id = 0
         self._connected = False
+        self.uri = uri
 
     def __enter__(self):
         self._protocol.__enter__()

--- a/wake/development/utils.py
+++ b/wake/development/utils.py
@@ -25,12 +25,11 @@ from typing import (
     TypeVar,
     Union,
 )
-from urllib.error import URLError
+from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from Crypto.Hash import keccak
-from eth_utils.abi import function_abi_to_4byte_selector
 from pydantic import TypeAdapter, ValidationError
 
 from ..compiler import SolcOutputSelectionEnum, SolidityCompiler
@@ -147,58 +146,6 @@ chain_explorer_urls: Dict[int, ChainExplorer] = {
         "https://api-holesky.etherscan.io/api",
     ),
 }
-
-
-@lru_cache(maxsize=1024)
-def get_contract_info_from_explorer(
-    addr: Address, chain_id: int
-) -> Optional[Tuple[str, Dict]]:
-    if chain_id not in chain_explorer_urls:
-        return None
-
-    config = get_config()
-    api_key = config.api_keys.get(chain_explorer_urls[chain_id].config_key, None)
-    if api_key is None:
-        return None
-
-    url = (
-        chain_explorer_urls[chain_id].api_url
-        + f"?module=contract&action=getsourcecode&address={addr}&apikey={api_key}"
-    )
-
-    req = Request(
-        url,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": f"wake/{get_package_version('eth-wake')}",
-        },
-    )
-
-    try:
-        with urlopen(req) as response:
-            ret = json.loads(response.read().decode("utf-8"))
-    except URLError as e:
-        return None
-
-    if ret["status"] != "1":
-        return None
-
-    data = ret["result"][0]
-    if data["ContractName"] == "":
-        return None
-
-    abi = {}
-    # TODO library ABI is different and has to be fixed to compute the correct selector
-    # however, it is not possible to detect if a contract is a library or not without parsing the source code
-    for abi_item in json.loads(data["ABI"]):
-        if abi_item["type"] in {"constructor", "fallback", "receive"}:
-            abi[abi_item["type"]] = abi_item
-        elif abi_item["type"] == "function":
-            abi[function_abi_to_4byte_selector(abi_item)] = abi_item
-        elif abi_item["type"] == "error":
-            abi[function_abi_to_4byte_selector(abi_item)] = abi_item
-
-    return data["ContractName"], abi
 
 
 def format_int(x: int) -> str:
@@ -1590,139 +1537,185 @@ def _try_change_erc1155_total_supply(
         raise ValueError("Total supply change failed")
 
 
-def get_info_from_explorer(addr: str, chain_id: int) -> Dict[str, Any]:
-    u = urlparse(chain_explorer_urls[chain_id].url)
-    config = get_config()
-    api_key = config.api_keys.get(".".join(u.netloc.split(".")[:-1]), None)
-    if api_key is None:
-        raise ValueError(f"Contract not found and API key for {u.netloc} not provided")
+def get_name_abi_from_explorer(addr: str, chain_id: int) -> Tuple[str, List]:
+    info, source = get_info_from_explorer(addr, chain_id)
 
-    url = (
-        chain_explorer_urls[chain_id].api_url
-        + f"?module=contract&action=getsourcecode&address={addr}&apikey={api_key}"
-    )
-    req = Request(
-        url,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": f"wake/{get_package_version('eth-wake')}",
-        },
-    )
-
-    with urlopen(req) as response:
-        parsed = json.loads(response.read().decode("utf-8"))
-
-    if parsed["status"] != "1":
-        raise ValueError(f"Request to {u.netloc} failed: {parsed['result']}")
-
-    return parsed["result"][0]
+    if source == "sourcify":
+        metadata = json.loads(next(f for f in info["files"] if f["name"] == "metadata.json")["content"])
+        name = next(iter(metadata["settings"]["compilationTarget"].values()))
+        abi = metadata["output"]["abi"]
+        return name, abi
+    else:
+        # etherscan-like
+        name = info["ContractName"]
+        try:
+            abi = json.loads(info["ABI"])
+        except JSONDecodeError:
+            u = urlparse(chain_explorer_urls[chain_id].url)
+            raise ValueError(f"Could not get ABI from {u.netloc}")
+        return name, abi
 
 
+def get_info_from_explorer(addr: str, chain_id: int) -> Tuple[Dict[str, Any], str]:
+    if chain_id not in chain_explorer_urls:
+        api_key = None
+    else:
+        u = urlparse(chain_explorer_urls[chain_id].url)
+        config = get_config()
+        api_key = config.api_keys.get(".".join(u.netloc.split(".")[:-1]), None)
+
+    if api_key is not None:
+        url = (
+            chain_explorer_urls[chain_id].api_url
+            + f"?module=contract&action=getsourcecode&address={addr}&apikey={api_key}"
+        )
+        req = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": f"wake/{get_package_version('eth-wake')}",
+            },
+        )
+
+        with urlopen(req) as response:
+            parsed = json.loads(response.read().decode("utf-8"))
+
+        if parsed["status"] != "1":
+            raise ValueError(f"Request to {u.netloc} failed: {parsed['result']}")
+
+        return parsed["result"][0], "etherscan"
+    else:
+        url = f"https://sourcify.dev/server/files/any/{chain_id}/{addr}"
+
+        req = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": f"wake/{get_package_version('eth-wake')}",
+            },
+        )
+
+        try:
+            with urlopen(req) as response:
+                parsed = json.loads(response.read().decode("utf-8"))
+        except HTTPError as e:
+            if e.code == 404:
+                raise ValueError(f"Contract not found on sourcify.eth") from None
+            else:
+                raise
+
+        return parsed, "sourcify"
+
+
+# should already be called with address of implementation contract
 @functools.lru_cache(maxsize=64)
 def _get_storage_layout_from_explorer(
     addr: str, chain_id: int
 ) -> SolcOutputStorageLayout:
     loop = asyncio.get_event_loop()
 
-    u = urlparse(chain_explorer_urls[chain_id].url)
+    info, source = get_info_from_explorer(addr, chain_id)
     config = get_config()
-    api_key = config.api_keys.get(".".join(u.netloc.split(".")[:-1]), None)
-    if api_key is None:
-        raise ValueError(f"Contract not found and API key for {u.netloc} not provided")
 
-    url = (
-        chain_explorer_urls[chain_id].api_url
-        + f"?module=contract&action=getsourcecode&address={addr}&apikey={api_key}"
-    )
-    req = Request(
-        url,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": f"wake/{get_package_version('eth-wake')}",
-        },
-    )
+    if source == "sourcify":
+        # sourcify is currently Solidity-only
+        metadata = json.loads(next(f for f in info["files"] if f["name"] == "metadata.json")["content"])
+        name = next(iter(metadata["settings"]["compilationTarget"].values()))
 
-    with urlopen(req) as response:
-        parsed = json.loads(response.read().decode("utf-8"))
-
-    if parsed["status"] != "1":
-        raise ValueError(f"Request to {u.netloc} failed: {parsed['result']}")
-
-    if "Proxy" in parsed["result"][0] and parsed["result"][0]["Proxy"] == "1":
-        return _get_storage_layout_from_explorer(
-            parsed["result"][0]["Implementation"], chain_id
-        )
-
-    version: str = parsed["result"][0]["CompilerVersion"]
-    if version.startswith("vyper"):
-        raise ValueError("Cannot set balance of Vyper contract")
-
-    if version.startswith("v"):
-        version = version[1:]
-    parsed_version = SolidityVersion.fromstring(version)
-
-    if parsed_version < SolidityVersion(0, 5, 13):
-        # storageLayout is only available in 0.5.13 and above
-        raise ValueError(f"Solidity version {parsed_version} too low, must be >=0.5.13")
-
-    optimizations = bool(parsed["result"][0]["OptimizationUsed"])
-    runs = parsed["result"][0]["Runs"]
-
-    config_dict = {
-        "compiler": {
-            "solc": {
-                "target_version": str(parsed_version),
-                "optimizer": {
-                    "enabled": optimizations,
-                    "runs": runs,
-                },
-            }
-        }
-    }
-
-    svm = SolcVersionManager(config)
-    if not svm.installed(parsed_version):
-        loop.run_until_complete(svm.install(parsed_version))
-
-    code = parsed["result"][0]["SourceCode"]
-    try:
-        standard_input: SolcInput = SolcInput.model_validate_json(code[1:-1])
-        if any(
-            PurePosixPath(filename).is_absolute()
-            for filename in standard_input.sources.keys()
-        ):
-            raise ValueError("Absolute paths not allowed")
-        if (
-            standard_input.settings is not None
-            and standard_input.settings.remappings is not None
-        ):
-            config_dict["compiler"]["solc"][
-                "remappings"
-            ] = standard_input.settings.remappings
-
-        if any(source.urls is not None for source in standard_input.sources.values()):
-            raise NotImplementedError("Compilation from URLs not supported")
+        version = SolidityVersion.fromstring(metadata["compiler"]["version"])
 
         sources = {
-            config.project_root_path / path: source.content
-            for path, source in standard_input.sources.items()
+            config.project_root_path / PurePosixPath(*PurePosixPath(file["path"]).parts[5:]): file["content"]
+            for file in info["files"]
+            if file["name"].endswith(".sol")
         }
-    except ValidationError:
-        try:
-            a = TypeAdapter(Dict[str, SolcInputSource])
-            s = a.validate_json(code)
-            if any(PurePosixPath(filename).is_absolute() for filename in s.keys()):
-                raise ValueError("Absolute paths not allowed")
 
-            if any(source.urls is not None for source in s.values()):
+        config_dict = {
+            "compiler": {
+                "solc": {
+                    "target_version": str(version),
+                    "evm_version": metadata["settings"]["evmVersion"],
+                    "remappings": metadata["settings"]["remappings"],
+                    "optimizer": metadata["settings"]["optimizer"],
+                }
+                # TODO libraries should not be needed
+            }
+        }
+    else:
+        # etherscan-like
+        name = info["ContractName"]
+        compiler_version: str = info["CompilerVersion"]
+        if compiler_version.startswith("vyper"):
+            raise ValueError("Cannot set balance of Vyper contract")
+
+        if compiler_version.startswith("v"):
+            compiler_version = compiler_version[1:]
+        version = SolidityVersion.fromstring(compiler_version)
+
+        optimizations = bool(info["OptimizationUsed"])
+        runs = info["Runs"]
+
+        config_dict = {
+            "compiler": {
+                "solc": {
+                    "target_version": str(version),
+                    "optimizer": {
+                        "enabled": optimizations,
+                        "runs": runs,
+                    },
+                }
+            }
+        }
+        if "EVMVersion" in info and info["EVMVersion"] != "Default":
+            config_dict["compiler"]["solc"]["evm_version"] = info["EVMVersion"]
+
+        code = info["SourceCode"]
+        try:
+            standard_input: SolcInput = SolcInput.model_validate_json(code[1:-1])
+            if any(
+                PurePosixPath(filename).is_absolute()
+                for filename in standard_input.sources.keys()
+            ):
+                raise ValueError("Absolute paths not allowed")
+            if (
+                standard_input.settings is not None
+                and standard_input.settings.remappings is not None
+            ):
+                config_dict["compiler"]["solc"][
+                    "remappings"
+                ] = standard_input.settings.remappings
+
+            if any(source.urls is not None for source in standard_input.sources.values()):
                 raise NotImplementedError("Compilation from URLs not supported")
 
             sources = {
                 config.project_root_path / path: source.content
-                for path, source in s.items()
+                for path, source in standard_input.sources.items()
             }
-        except (ValidationError, JSONDecodeError):
-            sources = {config.project_root_path / "tmp.sol": code}
+        except ValidationError:
+            try:
+                a = TypeAdapter(Dict[str, SolcInputSource])
+                s = a.validate_json(code)
+                if any(PurePosixPath(filename).is_absolute() for filename in s.keys()):
+                    raise ValueError("Absolute paths not allowed")
+
+                if any(source.urls is not None for source in s.values()):
+                    raise NotImplementedError("Compilation from URLs not supported")
+
+                sources = {
+                    config.project_root_path / path: source.content
+                    for path, source in s.items()
+                }
+            except (ValidationError, JSONDecodeError):
+                sources = {config.project_root_path / "tmp.sol": code}
+
+    if version < SolidityVersion(0, 5, 13):
+        # storageLayout is only available in 0.5.13 and above
+        raise ValueError(f"Cannot get storage layout of contract written in Solidity {version}, must be >=0.5.13")
+
+    svm = SolcVersionManager(config)
+    if not svm.installed(version):
+        loop.run_until_complete(svm.install(version))
 
     compilation_config = WakeConfig.fromdict(
         config_dict,
@@ -1744,10 +1737,8 @@ def _get_storage_layout_from_explorer(
     solc_output = loop.run_until_complete(
         compiler.compile_unit_raw(
             compilation_units[0],
-            parsed_version,
-            compiler.create_build_settings(
-                [SolcOutputSelectionEnum.STORAGE_LAYOUT], None
-            ),
+            version,
+            compiler.create_build_settings([SolcOutputSelectionEnum.STORAGE_LAYOUT], None),
             dummy_logger,
         )
     )
@@ -1755,12 +1746,11 @@ def _get_storage_layout_from_explorer(
     if any(e.severity == SolcOutputErrorSeverityEnum.ERROR for e in solc_output.errors):
         raise ValueError("Errors during compilation")
 
-    contract_name = parsed["result"][0]["ContractName"]
     try:
         info = next(
-            c[contract_name]
+            c[name]
             for c in solc_output.contracts.values()
-            if contract_name in c
+            if name in c
         )
     except StopIteration:
         raise ValueError("Contract not found in compilation output")

--- a/wake/development/utils.py
+++ b/wake/development/utils.py
@@ -1287,6 +1287,16 @@ def _get_storage_layout(
         return SolcOutputStorageLayout.model_validate(obj._storage_layout)
 
 
+class AbiNotFound(Exception):
+    method: str
+    api_key_name: Optional[str] = None
+
+    def __init__(self, method: str, api_key_name: Optional[str] = None):
+        self.method = method
+        self.api_key_name = api_key_name
+        super().__init__(f"ABI not found using method: {method}")
+
+
 @lru_cache(maxsize=1024)
 def _detect_erc1155_balance_slot(
     erc1155: Account, account: Account, token_id: int
@@ -1551,17 +1561,16 @@ def get_name_abi_from_explorer(addr: str, chain_id: int) -> Tuple[str, List]:
         try:
             abi = json.loads(info["ABI"])
         except JSONDecodeError:
-            u = urlparse(chain_explorer_urls[chain_id].url)
-            raise ValueError(f"Could not get ABI from {u.netloc}")
+            raise AbiNotFound(method="etherscan")
         return name, abi
 
 
 def get_info_from_explorer(addr: str, chain_id: int) -> Tuple[Dict[str, Any], str]:
+    config = get_config()
     if chain_id not in chain_explorer_urls:
         api_key = None
     else:
         u = urlparse(chain_explorer_urls[chain_id].url)
-        config = get_config()
         api_key = config.api_keys.get(".".join(u.netloc.split(".")[:-1]), None)
 
     if api_key is not None:
@@ -1600,7 +1609,11 @@ def get_info_from_explorer(addr: str, chain_id: int) -> Tuple[Dict[str, Any], st
                 parsed = json.loads(response.read().decode("utf-8"))
         except HTTPError as e:
             if e.code == 404:
-                raise ValueError(f"Contract not found on sourcify.eth") from None
+                if chain_id in chain_explorer_urls:
+                    u = urlparse(chain_explorer_urls[chain_id].url)
+                    raise AbiNotFound(method="sourcify", api_key_name=".".join(u.netloc.split(".")[:-1])) from None
+                else:
+                    raise AbiNotFound(method="sourcify") from None
             else:
                 raise
 

--- a/wake/lsp/lsp_compiler.py
+++ b/wake/lsp/lsp_compiler.py
@@ -482,9 +482,13 @@ class LspCompiler:
 
                 for command_type, data in subprocess.responses.values():
                     if command_type == SubprocessCommandType.DETECTORS_FAILURE:
-                        await self.__server.log_message(f"Detectors error: {data}", MessageType.ERROR)
+                        await self.__server.log_message(
+                            f"Detectors error: {data}", MessageType.ERROR
+                        )
                     elif command_type == SubprocessCommandType.PRINTERS_FAILURE:
-                        await self.__server.log_message(f"Printers error: {data}", MessageType.ERROR)
+                        await self.__server.log_message(
+                            f"Printers error: {data}", MessageType.ERROR
+                        )
 
                 raise RuntimeError("Subprocess has terminated unexpectedly")
 
@@ -1163,7 +1167,10 @@ class LspCompiler:
                 if self.__perform_files_discovery:
                     while True:
                         try:
-                            for f in glob.iglob(str(self.__config.project_root_path / "**/*.sol"), recursive=True):
+                            for f in glob.iglob(
+                                str(self.__config.project_root_path / "**/*.sol"),
+                                recursive=True,
+                            ):
                                 file = Path(f)
                                 if not self.__file_excluded(file) and file.is_file():
                                     self.__discovered_files.add(file.resolve())
@@ -1517,7 +1524,9 @@ class LspCompiler:
         handler = LspLoggingHandler(logging_buffer)
         logger.addHandler(handler)
 
-        compilation_units = self.__compiler.build_compilation_units_maximize(graph, logger)
+        compilation_units = self.__compiler.build_compilation_units_maximize(
+            graph, logger
+        )
 
         for log in logging_buffer:
             await self.__server.log_message(log[0], log[1])
@@ -1651,7 +1660,14 @@ class LspCompiler:
         if progress_token is not None:
             await self.__server.progress_end(progress_token)
 
-        return True, contract_info, asts, errors, skipped_source_units, source_units_to_paths
+        return (
+            True,
+            contract_info,
+            asts,
+            errors,
+            skipped_source_units,
+            source_units_to_paths,
+        )
 
     async def __compile(
         self,
@@ -1735,7 +1751,9 @@ class LspCompiler:
         handler = LspLoggingHandler(logging_buffer)
         logger.addHandler(handler)
 
-        compilation_units = self.__compiler.build_compilation_units_maximize(graph, logger)
+        compilation_units = self.__compiler.build_compilation_units_maximize(
+            graph, logger
+        )
 
         for log in logging_buffer:
             await self.__server.log_message(log[0], log[1])
@@ -1819,11 +1837,17 @@ class LspCompiler:
                     # however, there may be other CUs compiling this file (for different subprojects) where compilation was successful
                     # to prevent the case where files from different subprojects depending on this file would be left orphaned,
                     # we need to remove them from the build as well
-                    files = {source_units_to_paths[to] for (_, to) in nx.edge_bfs(graph, [
-                        source_unit_name
-                        for source_unit_name in graph.nodes
-                        if graph.nodes[source_unit_name]["path"] == file
-                    ])}
+                    files = {
+                        source_units_to_paths[to]
+                        for (_, to) in nx.edge_bfs(
+                            graph,
+                            [
+                                source_unit_name
+                                for source_unit_name in graph.nodes
+                                if graph.nodes[source_unit_name]["path"] == file
+                            ],
+                        )
+                    }
                     files.add(file)
 
                     for file in files:
@@ -2039,11 +2063,17 @@ class LspCompiler:
                     # however, there may be other CUs compiling this file (for different subprojects) where compilation was successful
                     # to prevent the case where files from different subprojects depending on this file would be left orphaned,
                     # we need to remove them from the build as well
-                    files = {source_units_to_paths[to] for (_, to) in nx.edge_bfs(graph, [
-                        source_unit_name
-                        for source_unit_name in graph.nodes
-                        if graph.nodes[source_unit_name]["path"] == file
-                    ])}
+                    files = {
+                        source_units_to_paths[to]
+                        for (_, to) in nx.edge_bfs(
+                            graph,
+                            [
+                                source_unit_name
+                                for source_unit_name in graph.nodes
+                                if graph.nodes[source_unit_name]["path"] == file
+                            ],
+                        )
+                    }
                     files.add(file)
 
                     for file in files:
@@ -2105,7 +2135,9 @@ class LspCompiler:
                         # file was already processed
                         # index AST + register (possibly new) source unit name
                         self.__ir_reference_resolver.index_nodes(ast, path, cu.hash)
-                        self.__source_units[path]._source_unit_names.add(ast.absolute_path)
+                        self.__source_units[path]._source_unit_names.add(
+                            ast.absolute_path
+                        )
                         continue
                     elif cu not in compilation_units_per_file[path]:
                         # file recompiled but canonical AST not indexed yet
@@ -2119,7 +2151,9 @@ class LspCompiler:
                     self.__ir_reference_resolver.index_nodes(ast, path, cu.hash)
 
                     for prev_ast, prev_cu_hash in ast_index[path]:
-                        self.__ir_reference_resolver.index_nodes(prev_ast, path, prev_cu_hash)
+                        self.__ir_reference_resolver.index_nodes(
+                            prev_ast, path, prev_cu_hash
+                        )
 
                     interval_tree = IntervalTree()
                     init = IrInitTuple(
@@ -2421,7 +2455,10 @@ class LspCompiler:
                 # perform Solidity files discovery
                 while True:
                     try:
-                        for f in glob.iglob(str(self.__config.project_root_path / "**/*.sol"), recursive=True):
+                        for f in glob.iglob(
+                            str(self.__config.project_root_path / "**/*.sol"),
+                            recursive=True,
+                        ):
                             file = Path(f)
                             if not self.__file_excluded(file) and file.is_file():
                                 self.__discovered_files.add(file.resolve())

--- a/wake/lsp/lsp_compiler.py
+++ b/wake/lsp/lsp_compiler.py
@@ -1487,11 +1487,12 @@ class LspCompiler:
         Dict[str, Dict],
         Dict[str, Set[Tuple[str, Path, int, int]]],
         Dict[str, Tuple[str, Path]],
+        Dict[str, Path],
     ]:
         try:
             await self.__check_target_versions(show_message=True)
         except CompilationError:
-            return False, {}, {}, {}, {}
+            return False, {}, {}, {}, {}, {}
 
         modified_files = {
             path: info.text.encode("utf-8")
@@ -1510,7 +1511,7 @@ class LspCompiler:
         except CompilationError as e:
             await self.__server.show_message(str(e), MessageType.ERROR)
             await self.__server.log_message(str(e), MessageType.ERROR)
-            return False, {}, {}, {}, {}
+            return False, {}, {}, {}, {}, {}
 
         logging_buffer = []
         handler = LspLoggingHandler(logging_buffer)
@@ -1523,7 +1524,7 @@ class LspCompiler:
         logging_buffer.clear()
 
         if len(compilation_units) == 0:
-            return False, {}, {}, {}, {}
+            return False, {}, {}, {}, {}, {}
 
         subprojects = {cu.subproject for cu in compilation_units}
         build_settings = {
@@ -1590,7 +1591,7 @@ class LspCompiler:
             if progress_token is not None:
                 await self.__server.progress_end(progress_token)
 
-            return False, {}, {}, {}, {}
+            return False, {}, {}, {}, {}, {}
         finally:
             logger.removeHandler(handler)
 
@@ -1650,7 +1651,7 @@ class LspCompiler:
         if progress_token is not None:
             await self.__server.progress_end(progress_token)
 
-        return True, contract_info, asts, errors, skipped_source_units
+        return True, contract_info, asts, errors, skipped_source_units, source_units_to_paths
 
     async def __compile(
         self,

--- a/wake/lsp/methods.py
+++ b/wake/lsp/methods.py
@@ -142,3 +142,4 @@ class RequestMethodEnum(StrEnum):
     SAKE_GET_BALANCES = "wake/sake/getBalances"
     SAKE_SET_BALANCES = "wake/sake/setBalances"
     SAKE_GET_ABI = "wake/sake/getAbi"
+    SAKE_GET_ABI_WITH_PROXY = "wake/sake/getAbiWithProxy"

--- a/wake/lsp/methods.py
+++ b/wake/lsp/methods.py
@@ -125,6 +125,7 @@ class RequestMethodEnum(StrEnum):
     SET_TRACE = "$/setTrace"  # Notification
 
     # Sake
+    SAKE_PING = "wake/sake/ping"
     SAKE_CREATE_CHAIN = "wake/sake/createChain"
     SAKE_CONNECT_CHAIN = "wake/sake/connectChain"
     SAKE_DISCONNECT_CHAIN = "wake/sake/disconnectChain"

--- a/wake/lsp/methods.py
+++ b/wake/lsp/methods.py
@@ -126,6 +126,8 @@ class RequestMethodEnum(StrEnum):
 
     # Sake
     SAKE_PING = "wake/sake/ping"
+    SAKE_LOAD_WORKSPACE_STATE = "wake/sake/loadWorkspaceState"
+    SAKE_SAVE_WORKSPACE_STATE = "wake/sake/saveWorkspaceState"
     SAKE_CREATE_CHAIN = "wake/sake/createChain"
     SAKE_CONNECT_CHAIN = "wake/sake/connectChain"
     SAKE_DISCONNECT_CHAIN = "wake/sake/disconnectChain"

--- a/wake/lsp/methods.py
+++ b/wake/lsp/methods.py
@@ -139,3 +139,4 @@ class RequestMethodEnum(StrEnum):
     SAKE_SET_LABEL = "wake/sake/setLabel"
     SAKE_GET_BALANCES = "wake/sake/getBalances"
     SAKE_SET_BALANCES = "wake/sake/setBalances"
+    SAKE_GET_ABI = "wake/sake/getAbi"

--- a/wake/lsp/methods.py
+++ b/wake/lsp/methods.py
@@ -128,6 +128,8 @@ class RequestMethodEnum(StrEnum):
     SAKE_CREATE_CHAIN = "wake/sake/createChain"
     SAKE_CONNECT_CHAIN = "wake/sake/connectChain"
     SAKE_DISCONNECT_CHAIN = "wake/sake/disconnectChain"
+    SAKE_DUMP_STATE = "wake/sake/dumpState"
+    SAKE_LOAD_STATE = "wake/sake/loadState"
     SAKE_COMPILE = "wake/sake/compile"
     SAKE_GET_ACCOUNTS = "wake/sake/getAccounts"
     SAKE_DEPLOY = "wake/sake/deploy"

--- a/wake/lsp/methods.py
+++ b/wake/lsp/methods.py
@@ -125,6 +125,9 @@ class RequestMethodEnum(StrEnum):
     SET_TRACE = "$/setTrace"  # Notification
 
     # Sake
+    SAKE_CREATE_CHAIN = "wake/sake/createChain"
+    SAKE_CONNECT_CHAIN = "wake/sake/connectChain"
+    SAKE_DISCONNECT_CHAIN = "wake/sake/disconnectChain"
     SAKE_COMPILE = "wake/sake/compile"
     SAKE_GET_ACCOUNTS = "wake/sake/getAccounts"
     SAKE_DEPLOY = "wake/sake/deploy"

--- a/wake/lsp/protocol_structures.py
+++ b/wake/lsp/protocol_structures.py
@@ -84,6 +84,7 @@ class ErrorCodes(enum.IntEnum):
     ContentModified = -32801
     RequestCancelled = -32800
     AnvilNotFound = -33000
+    AbiNotFound = -33001
     # jsonrpcReservedErrorRangeStart = -32099
     # jsonrpcReservedErrorRangeEnd = -32000
     # lspReservedErrorRangeStart = -32899

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -168,7 +168,7 @@ def chain_connected(f):
         ):
             raise LspError(ErrorCodes.InvalidParams, "Chain instance not connected")
 
-        return await f(context, *args, **kwargs)
+        return await f(context, params, *args, **kwargs)
 
     return wrapper
 

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -192,6 +192,9 @@ class SakeContext:
         self.abi_by_fqn = {}
         self.libraries = {}
 
+    async def ping(self) -> SakeResult:
+        return SakeResult(success=True)
+
     async def create_chain(
         self, params: SakeCreateChainParams
     ) -> SakeCreateChainResult:

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -119,6 +119,9 @@ class SakeTransactParams(SakeCallParams):
 class SakeTransactResult(SakeResult):
     return_value: Optional[str]  # raw hex encoded bytes, None for Halt
     error: Optional[str]  # user-friendly error string, None for Success
+    events: List[
+        str
+    ]  # user-friendly event strings, in correct order, excluding events from reverting subtraces
     tx_receipt: Dict[str, Any]
     call_trace: Dict[str, Union[Optional[str], List]]
 
@@ -707,6 +710,7 @@ class SakeContext:
             return SakeTransactResult(
                 success=success,
                 error=call_trace.error_string,
+                events=call_trace.event_strings,
                 return_value=return_value,
                 tx_receipt=tx._tx_receipt,
                 call_trace=call_trace.dict(self.lsp_context.config),

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -532,9 +532,7 @@ class SakeContext:
                         "big",
                     )
                     metadata = bytes.fromhex(
-                        info.evm.deployed_bytecode.object[
-                            -metadata_length * 2 - 4 : -4
-                        ]
+                        info.evm.deployed_bytecode.object[-metadata_length * 2 - 4 : -4]
                     )
                     self.fqn_by_metadata[metadata] = fqn
 

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -96,6 +96,9 @@ class SakeDeployResult(SakeResult):
     contract_address: Optional[str]
     raw_error: Optional[str]  # raw hex encoded bytes, None for Success or Halt
     error: Optional[str]  # user-friendly error string, None for Success
+    events: List[
+        str
+    ]  # user-friendly event strings, in correct order, excluding events from reverting subtraces
     tx_receipt: Dict[str, Any]
     call_trace: Dict[str, Union[Optional[str], List]]
 
@@ -651,6 +654,7 @@ class SakeContext:
             return SakeDeployResult(
                 success=success,
                 error=call_trace.error_string,
+                events=call_trace.event_strings,
                 raw_error=(
                     tx.raw_error.data.hex()
                     if isinstance(tx.raw_error, UnknownTransactionRevertedError)

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -263,10 +263,11 @@ class SakeContext:
             raise LspError(ErrorCodes.InternalError, str(e)) from None
 
     @chain_connected
-    async def disconnect_chain(self, params: SakeParams) -> None:
+    async def disconnect_chain(self, params: SakeParams) -> SakeResult:
         try:
             self.chains[params.session_id][1].__exit__(None, None, None)
             del self.chains[params.session_id]
+            return SakeResult(success=True)
         except Exception as e:
             raise LspError(ErrorCodes.InternalError, str(e)) from None
 
@@ -296,7 +297,7 @@ class SakeContext:
             raise LspError(ErrorCodes.InternalError, str(e)) from None
 
     @chain_connected
-    async def load_state(self, params: SakeLoadStateParams) -> None:
+    async def load_state(self, params: SakeLoadStateParams) -> SakeResult:
         chain = self.chains[params.session_id][0]
 
         if not isinstance(chain.chain_interface, AnvilChainInterface):
@@ -317,6 +318,7 @@ class SakeContext:
                     wake.development.core.Library(Address(addr), chain)
                     for addr in addrs
                 ]
+            return SakeResult(success=True)
         except Exception as e:
             raise LspError(ErrorCodes.InternalError, str(e)) from None
 
@@ -697,10 +699,11 @@ class SakeContext:
             raise LspError(ErrorCodes.InternalError, str(e)) from None
 
     @chain_connected
-    async def set_label(self, params: SakeSetLabelParams) -> None:
+    async def set_label(self, params: SakeSetLabelParams) -> SakeResult:
         chain = self.chains[params.session_id][0]
 
         try:
             Account(params.address, chain=chain).label = params.label
+            return SakeResult(success=True)
         except Exception as e:
             raise LspError(ErrorCodes.InternalError, str(e)) from None

--- a/wake/lsp/sake.py
+++ b/wake/lsp/sake.py
@@ -99,20 +99,6 @@ class SakeDeployResult(SakeResult):
     call_trace: Dict[str, Union[Optional[str], List]]
 
 
-class SakeTransactParams(LspModel):
-    contract_address: str
-    sender: str
-    calldata: str
-    value: int
-
-
-class SakeTransactResult(SakeResult):
-    return_value: Optional[str]  # raw hex encoded bytes, None for Halt
-    error: Optional[str]  # user-friendly error string, None for Success
-    tx_receipt: Dict[str, Any]
-    call_trace: Dict[str, Union[Optional[str], List]]
-
-
 class SakeCallParams(SakeParams):
     contract_address: str
     sender: str
@@ -123,6 +109,16 @@ class SakeCallParams(SakeParams):
 class SakeCallResult(SakeResult):
     return_value: str
     call_trace: Optional[Dict[str, Union[Optional[str], List]]]
+
+
+class SakeTransactParams(SakeCallParams):
+    pass
+
+class SakeTransactResult(SakeResult):
+    return_value: Optional[str]  # raw hex encoded bytes, None for Halt
+    error: Optional[str]  # user-friendly error string, None for Success
+    tx_receipt: Dict[str, Any]
+    call_trace: Dict[str, Union[Optional[str], List]]
 
 
 class SakeGetBalancesParams(SakeParams):
@@ -566,7 +562,7 @@ class SakeContext:
             raise LspError(ErrorCodes.InternalError, str(e)) from None
 
     @chain_connected
-    async def transact(self, params: SakeCallParams) -> SakeTransactResult:
+    async def transact(self, params: SakeTransactParams) -> SakeTransactResult:
         chain = self.chains[params.session_id][0]
 
         def fqn_to_contract_abi(fqn: str):

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -427,6 +427,14 @@ class LspServer:
                 ),
                 SakeGetAbiParams,
             ),
+            RequestMethodEnum.SAKE_GET_ABI_WITH_PROXY: (
+                lambda params: (
+                    self.__sake_context.get_abi_with_proxy(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
+                ),
+                SakeGetAbiParams,
+            ),
         }
 
         self.__notification_mapping = {

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -137,6 +137,7 @@ from .sake import (
     SakeGetAbiParams,
     SakeGetBalancesParams,
     SakeLoadStateParams,
+    SakeLoadWorkspaceStateParams,
     SakeParams,
     SakeSetBalancesParams,
     SakeSetLabelParams,
@@ -307,6 +308,20 @@ class LspServer:
             RequestMethodEnum.SAKE_PING: (
                 lambda params: (
                     self.__sake_context.ping()  # pyright: ignore reportAttributeAccessIssue
+                ),
+                None,
+            ),
+            RequestMethodEnum.SAKE_LOAD_WORKSPACE_STATE: (
+                lambda params: (
+                    self.__sake_context.load_workspace_state(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
+                ),
+                SakeLoadWorkspaceStateParams,
+            ),
+            RequestMethodEnum.SAKE_SAVE_WORKSPACE_STATE: (
+                lambda params: (
+                    self.__sake_context.save_workspace_state()  # pyright: ignore reportAttributeAccessIssue
                 ),
                 None,
             ),

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -135,6 +135,7 @@ from .sake import (
     SakeCreateChainParams,
     SakeDeployParams,
     SakeGetBalancesParams,
+    SakeLoadStateParams,
     SakeParams,
     SakeSetBalancesParams,
     SakeSetLabelParams,
@@ -317,6 +318,22 @@ class LspServer:
                     )
                 ),
                 SakeParams,
+            ),
+            RequestMethodEnum.SAKE_DUMP_STATE: (
+                lambda params: (
+                    self.__sake_context.dump_state(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
+                ),
+                SakeParams,
+            ),
+            RequestMethodEnum.SAKE_LOAD_STATE: (
+                lambda params: (
+                    self.__sake_context.load_state(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
+                ),
+                SakeLoadStateParams,
             ),
             RequestMethodEnum.SAKE_COMPILE: (
                 lambda params: (

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -305,9 +305,7 @@ class LspServer:
             ),
             RequestMethodEnum.SAKE_PING: (
                 lambda params: (
-                    self.__sake_context.ping(  # pyright: ignore reportAttributeAccessIssue
-                        params,
-                    )
+                    self.__sake_context.ping()  # pyright: ignore reportAttributeAccessIssue
                 ),
                 None,
             ),

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -135,6 +135,7 @@ from .sake import (
     SakeCreateChainParams,
     SakeDeployParams,
     SakeGetAbiParams,
+    SakeGetAbiWithProxyParams,
     SakeGetBalancesParams,
     SakeLoadStateParams,
     SakeLoadWorkspaceStateParams,
@@ -433,7 +434,7 @@ class LspServer:
                         params,
                     )
                 ),
-                SakeGetAbiParams,
+                SakeGetAbiWithProxyParams,
             ),
         }
 

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -343,9 +343,11 @@ class LspServer:
             ),
             RequestMethodEnum.SAKE_GET_ACCOUNTS: (
                 lambda params: (
-                    self.__sake_context.get_accounts()  # pyright: ignore reportAttributeAccessIssue
+                    self.__sake_context.get_accounts(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
                 ),
-                None,
+                SakeParams,
             ),
             RequestMethodEnum.SAKE_DEPLOY: (
                 lambda params: (

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -134,6 +134,7 @@ from .sake import (
     SakeContext,
     SakeCreateChainParams,
     SakeDeployParams,
+    SakeGetAbiParams,
     SakeGetBalancesParams,
     SakeLoadStateParams,
     SakeParams,
@@ -402,6 +403,14 @@ class LspServer:
                     )
                 ),
                 SakeSetBalancesParams,
+            ),
+            RequestMethodEnum.SAKE_GET_ABI: (
+                lambda params: (
+                    self.__sake_context.get_abi(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
+                ),
+                SakeGetAbiParams,
             ),
         }
 

--- a/wake/lsp/server.py
+++ b/wake/lsp/server.py
@@ -303,6 +303,14 @@ class LspServer:
                 ),
                 SakeCreateChainParams,
             ),
+            RequestMethodEnum.SAKE_PING: (
+                lambda params: (
+                    self.__sake_context.ping(  # pyright: ignore reportAttributeAccessIssue
+                        params,
+                    )
+                ),
+                None,
+            ),
             RequestMethodEnum.SAKE_CONNECT_CHAIN: (
                 lambda params: (
                     self.__sake_context.connect_chain(  # pyright: ignore reportAttributeAccessIssue

--- a/wake/templates/scripts/deploy.py
+++ b/wake/templates/scripts/deploy.py
@@ -3,6 +3,6 @@ from wake.deployment import *
 NODE_URL = "ENTER_NODE_URL_HERE"
 
 
-@default_chain.connect(NODE_URL)
+@chain.connect(NODE_URL)
 def main():
-    default_chain.set_default_accounts(Account.from_alias("deployment"))
+    chain.set_default_accounts(Account.from_alias("deployment"))

--- a/wake/templates/tests/test_default.py
+++ b/wake/templates/tests/test_default.py
@@ -5,7 +5,8 @@ from wake.testing import *
 #     if e.tx is not None:
 #         print(e.tx.call_trace)
 
-@default_chain.connect()
+
+@chain.connect()
 # @on_revert(revert_handler)
 def test_default():
     pass


### PR DESCRIPTION
## Description

- added events to call traces and Sake
- improved representation of bytes in call traces and deployment tx confirmation
- added Sourcify as a prioritized alternative to Etherscan-like explorers
- now accepting as Geth-like node, assuming Geth interface and behavior
- added support for sessions and state dumping and loading into Sake
- updated templates not to use obsolete `default_chain`

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"