### PR TITLE
Update changelog.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -390,7 +390,7 @@ Fixes:
     - added link to InlineAssembly from all Yul nodes
 
 - updated control flow graph
-    - Yul is now fully supported; InlineAssembly blocks are now decomposed into Yul statemenets
+    - Yul is now fully supported; InlineAssembly blocks are now decomposed into Yul statements
     - successful execution and reverting execution is now distinguished in control flow graph
     - assert/require/revert function calls are now handled (including these calls in conditionals)
     - fixed missing edge for in try/catch statement


### PR DESCRIPTION
## 📝 Update `changelog.md` – Fix Typo  

### 🔍 Description  
This PR corrects a small typo in `docs/changelog.md`:  
- Fixed **"statemenets" → "statements"** for proper spelling and clarity.  

### ✅ Checklist  
- [x] Typo fixed  
- [ ] No functional or structural changes to the documentation  
- [ ] Follows project contribution guidelines  

### 🔗 Related Issues  
N/A  

### 🔎 How to Review  
1. Verify the typo correction in `changelog.md`.  
2. Ensure no unintended modifications.  

A minor fix to enhance readability! 🚀 Let me know if anything needs changes.  
