### PR TITLE
Typos fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -202,7 +202,7 @@ Features & improvements:
 
 - implemented callback commands for LSP printers
     - go to locations, peek locations, open URI, copy to clipboard
-- Wake `console.log` is now tread as library (in respect to detectors)
+- Wake `console.log` is now thread, treat as library (in respect to detectors)
 - Wake `console.log` is now auto-completed in Solidity imports through LSP
 - random seeds used in testing are now printed in pytest summary
 - documented possible test reproducibility issues and their solutions


### PR DESCRIPTION
### Changes

1. **File:** `/docs/changelog.md`
    - Fixed `tread` to `thread, treat` (Line 205)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.