### PR TITLE
Fixed typos

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -390,7 +390,7 @@ Fixes:
     - added link to InlineAssembly from all Yul nodes
 
 - updated control flow graph
-    - Yul is now fully supported; InlineAssembly blocks are now decomposed into Yul statemenets
+    - Yul is now fully supported; InlineAssembly blocks are now decomposed into Yul statements
     - successful execution and reverting execution is now distinguished in control flow graph
     - assert/require/revert function calls are now handled (including these calls in conditionals)
     - fixed missing edge for in try/catch statement


### PR DESCRIPTION
### Changes

1. **File:** `/docs/changelog.md`
    - Fixed `statemenets` to `statements` (Line 393)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.