### PR TITLE
Fixes in `wake open` command

### DIFF
--- a/wake/cli/open.py
+++ b/wake/cli/open.py
@@ -109,7 +109,7 @@ async def open_address(
         col=0,
     )
 
-    if project_dir.exists() and not force:
+    if project_dir.exists() and any(project_dir.iterdir()) and not force:
         console.print(f"{address} already exists at [link={link}]{project_dir}[/link]")
         return
 

--- a/wake/cli/open.py
+++ b/wake/cli/open.py
@@ -49,6 +49,7 @@ def run_open(
     if force and path is not None:
         raise click.ClickException("Cannot use both --path and --force")
 
+    # ethereum address
     if all(char in "xabcdef0123456789" for char in uri.lower()):
         try:
             if uri.lower().startswith("0x") and len(uri) == 42:
@@ -58,15 +59,14 @@ def run_open(
                 uri = "0x" + uri
             else:
                 raise ValueError()
-
-            # ethereum address
-            asyncio.run(
-                open_address(
-                    uri, chain, None if path is None else Path(path).resolve(), force
-                )
-            )
         except ValueError:
             raise ValueError("Invalid ethereum address")
+
+        asyncio.run(
+            open_address(
+                uri, chain, None if path is None else Path(path).resolve(), force
+            )
+        )
 
     # github repository
     else:

--- a/wake/cli/open.py
+++ b/wake/cli/open.py
@@ -49,22 +49,27 @@ def run_open(
     if force and path is not None:
         raise click.ClickException("Cannot use both --path and --force")
 
-    try:
-        if uri.lower().startswith("0x") and len(uri) == 42:
-            int(uri, 16)
-        elif len(uri) == 40:
-            int(uri, 16)
-        else:
-            raise ValueError()
+    if all(char in "xabcdef0123456789" for char in uri.lower()):
+        try:
+            if uri.lower().startswith("0x") and len(uri) == 42:
+                int(uri, 16)
+            elif not uri.lower().startswith("0x") and len(uri) == 40:
+                int(uri, 16)
+                uri = "0x" + uri
+            else:
+                raise ValueError()
 
-        # ethereum address
-        asyncio.run(
-            open_address(
-                uri, chain, None if path is None else Path(path).resolve(), force
+            # ethereum address
+            asyncio.run(
+                open_address(
+                    uri, chain, None if path is None else Path(path).resolve(), force
+                )
             )
-        )
-    except ValueError:
-        # github repository
+        except ValueError:
+            raise ValueError("Invalid ethereum address")
+
+    # github repository
+    else:
         open_github(uri, branch, None if path is None else Path(path).resolve(), force)
 
 

--- a/wake/cli/open.py
+++ b/wake/cli/open.py
@@ -128,6 +128,9 @@ async def open_address(
         with urllib.request.urlopen(url) as response:
             parsed = json.loads(response.read())
 
+    if parsed["status"] == "0":
+        raise ValueError(f"API returned error: {parsed['result']}")
+
     version: str = parsed["result"][0]["CompilerVersion"]
     if version.startswith("vyper"):
         raise NotImplementedError("Vyper contracts are not supported")

--- a/wake/cli/open.py
+++ b/wake/cli/open.py
@@ -43,6 +43,12 @@ def run_open(
 ) -> None:
     """
     Fetch project from Github or Etherscan-like explorer.
+
+    For Etherscan explorer, API key is required:
+
+    - Create an API key for Etherscan  =>  https://docs.etherscan.io/getting-started/viewing-api-usage-statistics#creating-an-api-key
+
+    - Configure the API key in Wake    =>  https://ackee.xyz/wake/docs/latest/configuration
     """
     import asyncio
 


### PR DESCRIPTION
## Description

- Validates, if the passed address is valid and if not, reverts with `ValueError: Invalid ethereum address`
   - Previously was reverting with `"ValueError: Invalid github repository"`
- If the address is valid and without the `0x` prefix, add the prefix to avoid multiple directories of the same address
- If Etherscan returns an error, revert to the error message
   -  For example, if the API key is missing, revert with `"ValueError: API returned error: Missing/Invalid API Key"`
- If the directory exits, but it's empty, treat it the same way as a non-existent one
- Adds support links to documentation of Wake and Etherscan when running `wake open --help`

## Related Tickets & Documents

- Fixes issues I found while using the `wake open` command

- [x] I clicked on "Allow edits from maintainers"