### PR TITLE
🔥 Delete redundant iteration

### DIFF
--- a/wake/analysis/cfg.py
+++ b/wake/analysis/cfg.py
@@ -165,9 +165,7 @@ class ControlFlowGraph:
         ):
             pass
 
-        self._statements_lookup = {
-            stmt: node for node in self._graph.nodes for stmt in node.statements
-        }
+        self._statements_lookup = {}
         for node in self._graph.nodes:
             for stmt in node.statements:
                 self._statements_lookup[stmt] = node


### PR DESCRIPTION
## Description

deleting redundant assigning during declaration, because assigning is executed in the code below

- [x] I clicked on "Allow edits from maintainers"