### PR TITLE
📝 Global symbols - add enums info

### DIFF
--- a/wake/ir/enums.py
+++ b/wake/ir/enums.py
@@ -82,11 +82,15 @@ class GlobalSymbol(IntEnum):
 
     # available for contracts and interfaces
     TYPE_NAME = -800
+
+    # available for contracts only
     TYPE_CREATION_CODE = -801
     TYPE_RUNTIME_CODE = -802
+
     # available for interfaces only
     TYPE_INTERFACE_ID = -803
-    # available for integers
+
+    # available for integers and enums
     TYPE_MIN = -804
     TYPE_MAX = -805
 


### PR DESCRIPTION
## Description
- Add info about validity of `.min` and `.max` for enums – returns the min/max enum value
- Format the comments

## Related Tickets & Documents
https://docs.soliditylang.org/en/latest/types.html#enums

## Acknowledgement
- [x] I clicked on "Allow edits from maintainers"