### PR TITLE
🐛 Fix authorization list missing in TxParams

### DIFF
--- a/wake/development/chain_interfaces.py
+++ b/wake/development/chain_interfaces.py
@@ -34,6 +34,7 @@ TxParams = TypedDict(
         "maxFeePerGas": int,
         "accessList": Union[List, Literal["auto"]],
         "chainId": int,
+        "authorizationList": List,
     },
     total=False,
 )
@@ -83,6 +84,8 @@ class ChainInterfaceAbc(ABC):
             tx["accessList"] = transaction["accessList"]
         if "chainId" in transaction:
             tx["chainId"] = hex(transaction["chainId"])
+        if "authorizationList" in transaction:
+            tx["authorizationList"] = transaction["authorizationList"]
         return tx
 
     @staticmethod


### PR DESCRIPTION
The extension started failing on deployment with the following error message:

```
Wake API Error argument 'authorization_list': 'type' object cannot be converted to 'Sequence'
```

See foundry code containing the `authorization_list`:
https://github.com/foundry-rs/foundry/blob/21e7ebcb5613bb578a6d8ed6b62b38dceb37def8/crates/common/src/transactions.rs#L259