### PR TITLE
Fix/shrink option

### DIFF
--- a/docs/wake-schema.json
+++ b/docs/wake-schema.json
@@ -195,7 +195,7 @@
       "properties": {
         "cmd": {
           "type": "string",
-          "enum": ["anvil", "hardhat"],
+          "enum": ["revm", "anvil", "hardhat"],
           "default": "anvil",
           "description": "Which development chain to use for testing"
         },

--- a/wake/cli/test.py
+++ b/wake/cli/test.py
@@ -90,7 +90,7 @@ class FileAndPassParamType(click.ParamType):
     help="Increase verbosity. Can be specified multiple times.",
 )
 @click.option(
-    "-RS",
+    "-R",
     "--random-state",
     type=str,
     help="Input random state json path.",
@@ -100,7 +100,7 @@ class FileAndPassParamType(click.ParamType):
     required=False,
 )
 @click.option(
-    "-SH",
+    "-C",
     "--shrink",
     # Didn't use click.Path since we accept relative index of crash log file
     type=str,
@@ -126,7 +126,7 @@ class FileAndPassParamType(click.ParamType):
     help="When shrinking, check only target invariants for faster fuzzing.",
 )
 @click.option(
-    "-SR",
+    "-r",
     "--shrunk",
     "--shrank",
     "--reproduce",

--- a/wake/cli/test.py
+++ b/wake/cli/test.py
@@ -90,7 +90,6 @@ class FileAndPassParamType(click.ParamType):
     help="Increase verbosity. Can be specified multiple times.",
 )
 @click.option(
-    "-R",
     "--random-state",
     type=str,
     help="Input random state json path.",
@@ -100,7 +99,6 @@ class FileAndPassParamType(click.ParamType):
     required=False,
 )
 @click.option(
-    "-C",
     "--shrink",
     # Didn't use click.Path since we accept relative index of crash log file
     type=str,
@@ -126,7 +124,6 @@ class FileAndPassParamType(click.ParamType):
     help="When shrinking, check only target invariants for faster fuzzing.",
 )
 @click.option(
-    "-r",
     "--shrunk",
     "--reproduce",
     # Didn't use click.Path since we accept relative index of crash log file

--- a/wake/cli/test.py
+++ b/wake/cli/test.py
@@ -128,7 +128,6 @@ class FileAndPassParamType(click.ParamType):
 @click.option(
     "-r",
     "--shrunk",
-    "--shrank",
     "--reproduce",
     # Didn't use click.Path since we accept relative index of crash log file
     type=str,

--- a/wake/config/data_model.py
+++ b/wake/config/data_model.py
@@ -406,7 +406,8 @@ class TestingConfig(WakeConfigModel):
     """
     cmd: str = "anvil"
     """
-    Which development chain to use for testing. Should be either `anvil` or `hardhat`.
+    Which development chain to use for testing. Should be one of `revm`, `anvil`, or
+    `hardhat`.
     """
     anvil: AnvilConfig = Field(default_factory=AnvilConfig)
     """


### PR DESCRIPTION
## Description

Polished shrink-related CLI flags by replacing the confusing multi-letter shorts (-RS/-SH/-SR) with clear single-letter options (-R random state, -C shrink crash log, -r reproduce shrunk log), while keeping long flags intact. This makes wake test help output easier to scan and reduces flag collisions.

For shrinking from **C**rash log.
```bash
wake test -C 
```

For reproducing shrunk test
```bash
wake test -r
```

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"