### PR TITLE
Fix/version 4.22.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,16 @@ small.label {
 }
 </style>
 
+## 4.22.1 <small>(Mar 2, 2026)</small> { id="4.22.1" }
+
+Fixes & improvements:
+
+- added support for Solidity 0.8.34 <small class="label">[core]</small>
+- fixed solc JSON list fetching crashing due to missing User-Agent header <small class="label">[core]</small>
+- fixed remapping rules inconsistent with solc leading to compilation crashes <small class="label">[core]</small>
+- fixed compilation crashes caused by multiple symlinks pointing to the same file <small class="label">[core]</small>
+- fixed `AbstractChildWatcher` no longer present in Python 3.14 <small class="label">[core]</small>
+
 ## 4.22.0 <small>(Jan 3, 2026)</small> { id="4.22.0" }
 
 Features & improvements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eth-wake"
-version = "4.22.0"
+version = "4.22.1"
 description = "Wake is a Python-based Solidity development and testing framework with built-in vulnerability detectors."
 license = "ISC"
 authors = ["Ackee Blockchain"]

--- a/wake/cli/__main__.py
+++ b/wake/cli/__main__.py
@@ -22,7 +22,7 @@ from .run import run_run
 from .svm import run_svm
 from .test import run_test
 
-if platform.system() != "Windows":
+if platform.system() != "Windows" and sys.version_info < (3, 12):
     try:
         from asyncio import (
             ThreadedChildWatcher,  # pyright: ignore reportGeneralTypeIssues
@@ -206,7 +206,7 @@ def main(
 
     if platform.system() == "Windows":
         asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-    else:
+    elif sys.version_info < (3, 12):
         asyncio.get_event_loop_policy().set_child_watcher(
             ThreadedChildWatcher()  # pyright: ignore reportUnboundVariable
         )

--- a/wake/compiler/compiler.py
+++ b/wake/compiler/compiler.py
@@ -400,9 +400,9 @@ class SolidityCompiler:
         source_units: Dict[str, Path] = {}
 
         # for every source file resolve a source unit name
-        for file in files:
+        # resolve and deduplicate (avoid duplicates due to symlinks)
+        for file in {f.resolve() for f in files}:
             try:
-                file = file.resolve()
                 if file not in modified_files:
                     file = file.resolve(strict=True)
             except FileNotFoundError:

--- a/wake/config/wake_config.py
+++ b/wake/config/wake_config.py
@@ -536,7 +536,7 @@ class WakeConfig:
         Returns:
             Maximum supported Solidity version.
         """
-        return SolidityVersion.fromstring("0.8.33")
+        return SolidityVersion.fromstring("0.8.34")
 
     @property
     def detectors(self) -> DetectorsConfig:

--- a/wake/svm/svm.py
+++ b/wake/svm/svm.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, ValidationError
 from wake.config import UnsupportedPlatformError, WakeConfig
 from wake.core import get_logger
 from wake.core.solidity_version import SolidityVersion
+from wake.utils.version import get_package_version
 
 from .abc import CompilerVersionManagerAbc
 from .exceptions import ChecksumError, UnsupportedVersionError
@@ -58,6 +59,7 @@ class SolcVersionManager(CompilerVersionManagerAbc):
     __solc_list_path: Path
     __solc_builds: Optional[SolcBuilds]
     __list_force_loaded: bool
+    __headers: Dict[str, str]
 
     def __init__(self, wake_config: WakeConfig):
         system = platform.system()
@@ -84,6 +86,9 @@ class SolcVersionManager(CompilerVersionManagerAbc):
         self.__solc_list_path = self.__compilers_path / "solc.json"
         self.__solc_builds = None
         self.__list_force_loaded = False
+        self.__headers = {
+            "User-Agent": f"wake/{get_package_version('eth-wake')}",
+        }
 
         self.__compilers_path.mkdir(parents=True, exist_ok=True)
 
@@ -230,7 +235,7 @@ class SolcVersionManager(CompilerVersionManagerAbc):
         http_session: aiohttp.ClientSession,
         progress: Optional[Callable[[int, int], Awaitable[None]]] = None,
     ) -> None:
-        async with http_session.get(url) as r:
+        async with http_session.get(url, headers=self.__headers) as r:
             total_size = r.headers.get("Content-Length")
             if total_size is not None:
                 total_size = int(total_size)
@@ -298,7 +303,10 @@ class SolcVersionManager(CompilerVersionManagerAbc):
         try:
             logger.debug(f"Downloading solc list from {self.__solc_list_urls[0]}")
             with urllib.request.urlopen(
-                self.__solc_list_urls[0], timeout=5
+                urllib.request.Request(
+                    self.__solc_list_urls[0], headers=self.__headers
+                ),
+                timeout=5,
             ) as response:
                 json = response.read()
                 self.__solc_builds = SolcBuilds.model_validate_json(json)
@@ -312,7 +320,10 @@ class SolcVersionManager(CompilerVersionManagerAbc):
             try:
                 logger.debug(f"Downloading solc list from {self.__solc_list_urls[1]}")
                 with urllib.request.urlopen(
-                    self.__solc_list_urls[1], timeout=0.5
+                    urllib.request.Request(
+                        self.__solc_list_urls[1], headers=self.__headers
+                    ),
+                    timeout=0.5,
                 ) as response:
                     json = response.read()
                     self.__solc_builds = SolcBuilds.model_validate_json(json)

--- a/wake/utils/threaded_child_watcher.py
+++ b/wake/utils/threaded_child_watcher.py
@@ -12,6 +12,8 @@ logger = get_logger(__name__)
 
 """
 Backported ThreadedChildWatcher implementation from https://github.com/python/cpython/blob/5f0fe8ec70120f4586d08978b0911b436f82c421/Lib/asyncio/unix_events.py#L1326
+
+Only to be imported if Python < 3.12.
 """
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core compilation graph building and solc download/list fetching behavior, which could affect builds and installation across platforms if edge cases are missed. Changes are relatively small and targeted but impact critical paths.
> 
> **Overview**
> Bumps the package version to **4.22.1** and documents the release in `docs/changelog.md`, including **Solidity 0.8.34** support.
> 
> Fixes multiple core crash cases: deduplicates input files by resolved path in `SolidityCompiler.build_graph` to avoid duplicate compilation paths caused by symlinks, adds a `User-Agent` header (derived from the installed `eth-wake` version) to solc list/binary HTTP requests in `SolcVersionManager`, and gates use of the backported `ThreadedChildWatcher` to *Python < 3.12* to avoid `AbstractChildWatcher` removals in newer Python versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d05c269d6339797a3db4e43968c6ae3dda0fd1c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->