### PR TITLE
Fix access list storage key conversion for deployment transaction signing

### DIFF
--- a/wake/deployment/core.py
+++ b/wake/deployment/core.py
@@ -300,7 +300,13 @@ class Chain(wake.development.core.Chain):
                 tx_copy.pop("gasPrice", None)
                 tx_copy.pop("maxPriorityFeePerGas", None)
                 tx_copy.pop("maxFeePerGas", None)
-                tx_copy["accessList"] = response["accessList"]
+                converted_access_list = []
+                for entry in response["accessList"]:
+                    converted_access_list.append({
+                        "address": entry["address"],
+                        "storageKeys": [int(k, 16) for k in entry["storageKeys"]],
+                    })
+                tx_copy["accessList"] = converted_access_list
 
                 # gas estimate returned by eth_createAccessList cannot be trusted
                 try:
@@ -316,7 +322,7 @@ class Chain(wake.development.core.Chain):
                 if params.get("accessList") == "auto" or (
                     "accessList" not in params and gas_used <= tx["gas"]
                 ):
-                    tx["accessList"] = response["accessList"]
+                    tx["accessList"] = converted_access_list
                     tx["gas"] = gas_used
 
         return tx
@@ -434,6 +440,12 @@ class Chain(wake.development.core.Chain):
             tx_copy["maxFeePerGas"] = str(tx_copy["maxFeePerGas"])
         if "maxPriorityFeePerGas" in tx_copy:
             tx_copy["maxPriorityFeePerGas"] = str(tx_copy["maxPriorityFeePerGas"])
+        if "accessList" in tx_copy:
+            for entry in tx_copy["accessList"]:
+                entry["storageKeys"] = [
+                    "0x" + k.to_bytes(32, "big").hex()
+                    for k in entry["storageKeys"]
+                ]
 
         if get_verbosity() > 0:
             pprint(tx_copy, console=console, max_string=None)

--- a/wake/deployment/core.py
+++ b/wake/deployment/core.py
@@ -441,11 +441,16 @@ class Chain(wake.development.core.Chain):
         if "maxPriorityFeePerGas" in tx_copy:
             tx_copy["maxPriorityFeePerGas"] = str(tx_copy["maxPriorityFeePerGas"])
         if "accessList" in tx_copy:
-            for entry in tx_copy["accessList"]:
-                entry["storageKeys"] = [
-                    "0x" + k.to_bytes(32, "big").hex()
-                    for k in entry["storageKeys"]
-                ]
+            tx_copy["accessList"] = [
+                {
+                    "address": entry["address"],
+                    "storageKeys": [
+                        "0x" + k.to_bytes(32, "big").hex()
+                        for k in entry["storageKeys"]
+                    ],
+                }
+                for entry in tx_copy["accessList"]
+            ]
 
         if get_verbosity() > 0:
             pprint(tx_copy, console=console, max_string=None)

--- a/wake/development/chain_interfaces.py
+++ b/wake/development/chain_interfaces.py
@@ -95,7 +95,16 @@ class ChainInterfaceAbc(ABC):
             tx["maxFeePerGas"] = hex(transaction["maxFeePerGas"])
         if "accessList" in transaction:
             assert transaction["accessList"] != "auto"
-            tx["accessList"] = transaction["accessList"]
+            encoded_access_list = []
+            for entry in transaction["accessList"]:
+                encoded_access_list.append({
+                    "address": entry["address"],
+                    "storageKeys": [
+                        "0x" + k.to_bytes(32, "big").hex()
+                        for k in entry["storageKeys"]
+                    ],
+                })
+            tx["accessList"] = encoded_access_list
         if "authorizationList" in transaction:
             tx["authorizationList"] = [
                 {

--- a/wake_rs/src/utils.rs
+++ b/wake_rs/src/utils.rs
@@ -429,7 +429,12 @@ fn tx_params_access_list_convert<'py>(
             address,
             storage_keys: storage_keys
                 .iter()
-                .map(|key| B256::from_slice(&key.to_bytes_le()))
+                .map(|key| {
+                    let bytes = key.to_bytes_be();
+                    let mut padded = [0u8; 32];
+                    padded[32 - bytes.len()..].copy_from_slice(&bytes);
+                    B256::from(padded)
+                })
                 .collect(),
         });
     }


### PR DESCRIPTION

## Description

When sending transactions with `wake run`, `eth_createAccessList` returns storage keys as hex strings, but the Rust `sign_transaction` expects them as integers.
This caused a `TypeError: 'str' object cannot be interpreted as an integer` on every transaction with a non-empty access list.

Fixed by making hex value integer in python  for `AccessListItem` in rust, and still make show hex string during comfirmation.
<!--
Write a description of your pull request.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction building/encoding and Rust-side access list conversion, which affects how signed transactions are constructed and could break EIP-2930/1559 txs if mis-encoded. Scope is narrow and primarily type/byte-order conversion.
> 
> **Overview**
> Fixes `eth_createAccessList` handling by converting returned `storageKeys` from hex strings into integers when building deployment transactions, preventing type errors during signing.
> 
> Ensures access lists are still shown/serialized as 32-byte hex strings for JSON-RPC encoding and the interactive confirmation prompt, and updates the Rust `tx_params_access_list_convert` to build `B256` values from big-endian, 32-byte padded integers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dec2bb7278c3c2756b492fa84e28dff893745006. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->