### PR TITLE
ci: add cryptographic supply-chain notarization for PyPI release packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   pypi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v2
@@ -29,8 +32,18 @@ jobs:
     - name: Set up PyPi token
       run: poetry config pypi-token.pypi ${{ secrets.PYPI_DEPLOY_TOKEN }}
 
+    - name: Build package
+      run: poetry build
+
+    # 🛡️ ProofCore: Cryptographic supply-chain notarization for PyPI distribution packages
+    - name: Notarize PyPI Distribution Packages via ProofCore
+      uses: ProofCore-Protocol/proofcore-action@v1
+      continue-on-error: true
+      with:
+        files: "dist/*"
+
     - name: Upload to PyPI
-      run: poetry publish --build
+      run: poetry publish
 
   docker:
     needs: pypi


### PR DESCRIPTION
Hi Ackee Blockchain team! 👋

As fellow Web3 security enthusiasts, we really appreciate the work you're doing with Wake and Solidity developer tooling.

This PR adds automated, non-intrusive supply-chain security attestation to your PyPI release workflow using [ProofCore Action](https://github.com/ProofCore-Protocol/proofcore-action).

How it fits into your workflow:
    Splitted poetry publish --build into explicit poetry build and poetry publish.
    Between build and publish, ProofCore computes SHA-256 digests of the generated wheels and source archives in dist/* locally on the runner.
    Binds the hashes to your repository's cryptographic GitHub OIDC token and anchors the proof root on-chain.
    Allows security auditors and developers installing wake via PyPI to independently verify that their packages match the exact GitHub Actions build.

Zero friction & zero storage:
    Runs with continue-on-error: true so it will never block your release pipeline in case of external network timeouts.
    Raw code or binaries are never stored remotely (zero-storage model).

Happy to make any adjustments or answer questions! 🚀